### PR TITLE
fix(demo): correct basename for GitHub pages

### DIFF
--- a/demo/index.js
+++ b/demo/index.js
@@ -31,6 +31,9 @@ import '../node_modules/deque-pattern-library/dist/css/pattern-library.min.css';
 import '../src/index.css';
 import './index.css';
 
+const { NODE_ENV = 'development' } = process.env;
+const basename = NODE_ENV === 'development' ? '/' : '/cauldron-react/';
+
 class App extends Component {
   state = { show: false };
   constructor() {
@@ -66,7 +69,7 @@ class App extends Component {
   render() {
     /* eslint-disable jsx-a11y/anchor-has-content */
     return (
-      <Router>
+      <Router basename={basename}>
         <div>
           <SkipLink target={'#main-content'} />
           <TopBar hasTrigger={true}>


### PR DESCRIPTION
This patch updates the `<Router>`'s `basename` to handle being deployed to GitHub Pages. Previously (when deployed) the index wouldn't render since the router wouldn't match any routes.