### PR TITLE
feat: adds support for controlling checkbox with state

### DIFF
--- a/demo/patterns/components/Checkbox/index.css
+++ b/demo/patterns/components/Checkbox/index.css
@@ -1,3 +1,3 @@
-.food-submit.dqpl-button-primary {
+.mango-toggler.dqpl-button-primary {
   margin: 10px 0;
 }

--- a/demo/patterns/components/Checkbox/index.js
+++ b/demo/patterns/components/Checkbox/index.js
@@ -1,53 +1,120 @@
-import React from 'react';
+import React, { Component } from 'react';
 import Highlight from 'demo/Highlight';
 import { Checkbox, Button } from 'src/';
 import './index.css';
 
-const Demo = () => (
-  <div>
-    <h1>Checkbox</h1>
-    <h2>Demo</h2>
-    <h3 id="foods-label">Choose your favorite foods</h3>
-    <div role="group" aria-labelledby="foods-label">
-      <Checkbox
-        checked
-        id="artichokes"
-        name="foods"
-        value="artichokes"
-        label="Artichokes"
-      />
-      <Checkbox disabled id="liver" name="foods" value="liver" label="Liver" />
-      <Checkbox id="mangos" name="foods" value="mangos" label="Mangos" />
-      <Checkbox id="falafel" name="foods" value="falafel" label="Falafel" />
-    </div>
-    <Button className="food-submit">Submit</Button>
-    <h2>Code Sample</h2>
-    <Highlight language="javascript">
-      {`
-  import React from 'react';
+export default class Demo extends Component {
+  state = {
+    mangoChecked: false
+  };
+
+  onMangoToggle = () => {
+    const { mangoChecked } = this.state;
+    this.setState({
+      mangoChecked: !mangoChecked
+    });
+  };
+
+  handleMangoChange = (e, mangoChecked) => {
+    this.setState({ mangoChecked });
+  };
+
+  render() {
+    return (
+      <div>
+        <h1>Checkbox</h1>
+        <h2>Demo</h2>
+        <h3 id="foods-label">Choose your favorite foods</h3>
+        <div role="group" aria-labelledby="foods-label">
+          <Checkbox
+            checked
+            id="artichokes"
+            name="foods"
+            value="artichokes"
+            label="Artichokes"
+          />
+          <Checkbox
+            disabled
+            id="liver"
+            name="foods"
+            value="liver"
+            label="Liver"
+          />
+          <Checkbox
+            id="mangos"
+            name="foods"
+            value="mangos"
+            label="Mangos"
+            checked={this.state.mangoChecked}
+            onChange={this.handleMangoChange}
+          />
+          <Checkbox id="falafel" name="foods" value="falafel" label="Falafel" />
+        </div>
+        <p>
+          checked prop value changes will be picked up so you can
+          programmatically control the checked state of a checkbox.
+        </p>
+        <Button className="mango-toggler" onClick={this.onMangoToggle}>
+          Toggle mangos checked
+        </Button>
+        <h2>Code Sample</h2>
+        <Highlight language="javascript">
+          {`
+  import React, { Component } from 'react';
   import { Checkbox, Button } from 'cauldron-react';
 
-  const Demo = () => (
-    <div>
-      <h3 id='foods-label'>Choose your favorite foods</h3>
-      <div role='group' aria-labelledby='foods-label'>
-        <Checkbox checked id='artichokes' name='foods' value='artichokes' label='Artichokes' />
-        <Checkbox disabled id='liver' name='foods' value='liver' label='Liver' />
-        <Checkbox
-          id='mangos'
-          name='foods'
-          value='mangos'
-          label='Mangos'
-          onChange={(e, checked) => console.log('mangos changed!')}
-        />
-        <Checkbox id='falafel' name='foods' value='falafel' label='Falafel' />
-      </div>
-      <Button className='food-submit'>Submit</Button>
-    </div>
-  );
-      `}
-    </Highlight>
-  </div>
-);
+  class Demo extends Component {
+    state = { mangoChecked: false };
 
-export default Demo;
+    onMangoToggle = () => {
+      const { mangoChecked } = this.state;
+      this.setState({
+        mangoChecked: !mangoChecked
+      });
+    };
+
+    handleMangoChange = (e, mangoChecked) => {
+      this.setState({ mangoChecked });
+    };
+
+    render() {
+      return (
+        <h3 id="foods-label">Choose your favorite foods</h3>
+        <div role="group" aria-labelledby="foods-label">
+          <Checkbox
+            checked
+            id="artichokes"
+            name="foods"
+            value="artichokes"
+            label="Artichokes"
+            checkboxRef={checkbox => this.artichokeBox = checkbox}
+          />
+          <Checkbox
+            disabled
+            id="liver"
+            name="foods"
+            value="liver"
+            label="Liver"
+          />
+          <Checkbox
+            id="mangos"
+            name="foods"
+            value="mangos"
+            label="Mangos"
+            checked={this.state.mangoChecked}
+            onChange={this.handleMangoChange}
+          />
+          <Checkbox id="falafel" name="foods" value="falafel" label="Falafel" />
+        </div>
+        <Button className="mango-toggler" onClick={this.onMangoToggle}>
+          Toggle mangos checked
+        </Button>
+      );
+    }
+  }
+      `}
+        </Highlight>
+      </div>
+    );
+  }
+}

--- a/src/lib/components/Checkbox/index.js
+++ b/src/lib/components/Checkbox/index.js
@@ -11,13 +11,15 @@ export default class Checkbox extends Component {
     checked: PropTypes.bool,
     disabled: PropTypes.bool,
     className: PropTypes.string,
-    onChange: PropTypes.func
+    onChange: PropTypes.func,
+    checkboxRef: PropTypes.func
   };
 
   static defaultProps = {
     checked: false,
     disabled: false,
-    onChange: () => {}
+    onChange: () => {},
+    checkboxRef: () => {}
   };
 
   constructor(props) {
@@ -26,6 +28,14 @@ export default class Checkbox extends Component {
     this.toggleFocus = this.toggleFocus.bind(this);
     this.onCheckboxClick = this.onCheckboxClick.bind(this);
     this.onOverlayClick = this.onOverlayClick.bind(this);
+  }
+
+  componentDidUpdate(prevProps) {
+    const { checked } = this.props;
+
+    if (checked !== prevProps.checked) {
+      this.setState({ checked });
+    }
   }
 
   toggleFocus() {
@@ -45,6 +55,8 @@ export default class Checkbox extends Component {
 
   render() {
     const { checked, focused } = this.state;
+    // disabling no-unused-vars below to prevent specific
+    // props from being passed through to the wrapper
     const {
       id,
       value,
@@ -52,10 +64,10 @@ export default class Checkbox extends Component {
       label,
       disabled,
       className,
-      // disabling no-unused-vars to prevent onChange
-      // from being passed through to the wrapper
       // eslint-disable-next-line no-unused-vars
       onChange,
+      // eslint-disable-next-line no-unused-vars
+      checkboxRef,
       ...others
     } = this.props;
 
@@ -74,7 +86,10 @@ export default class Checkbox extends Component {
           value={value}
           onFocus={this.toggleFocus}
           onBlur={this.toggleFocus}
-          ref={checkbox => (this.checkbox = checkbox)}
+          ref={checkbox => {
+            this.checkbox = checkbox;
+            this.props.checkboxRef(checkbox);
+          }}
         />
         <div
           aria-hidden="true"

--- a/test/src/components/Checkbox/index.js
+++ b/test/src/components/Checkbox/index.js
@@ -21,6 +21,15 @@ test('Checkbox Component', t => {
     t.end();
   });
 
+  t.test('handles checked prop changes', t => {
+    const wrapper = mount(<Checkbox {...defaultProps} checked />);
+    wrapper.setProps({
+      checked: false
+    });
+    t.false(wrapper.find('[type="checkbox"]').getDOMNode().checked);
+    t.end();
+  });
+
   t.test('toggles checked state properly', t => {
     const wrapper = mount(<Checkbox {...defaultProps} />);
     const checkbox = wrapper.find('[type="checkbox"]');
@@ -82,5 +91,14 @@ test('Checkbox Component', t => {
       .find('[type="checkbox"]')
       .at(0)
       .simulate('change');
+  });
+
+  t.test('supports checkboxRef prop', t => {
+    const ref = checkbox => {
+      t.true(checkbox instanceof HTMLElement);
+      t.end();
+    };
+
+    mount(<Checkbox {...defaultProps} checkboxRef={ref} />);
   });
 });


### PR DESCRIPTION
* picks up on props.checked changes to support controlling checked state with internal state (see example below or in the demo code). Before, we only looked at props.checked initially (in the constructor), therefore updated values were essentially ignored
* adds a new `checkboxRef` prop
* updates demo/tests

```js
<Checkbox checked={this.state.checked} />
```