### PR TITLE
fix(TopBar): support falsy children

### DIFF
--- a/demo/index.js
+++ b/demo/index.js
@@ -83,6 +83,10 @@ class App extends Component {
                 Cauldron
               </Link>
             </MenuItem>
+
+            {/* The below line demonstrates the ability to conditionally include menu item children. */}
+            {false && <MenuItem>Potato</MenuItem>}
+
             <MenuItem className="dqpl-right-aligned">
               <a
                 tabIndex={-1}

--- a/src/components/TopBar/TopBar.js
+++ b/src/components/TopBar/TopBar.js
@@ -91,33 +91,38 @@ export default class TopBar extends Component {
     // disabling no-unused-vars to prevent hasTrigger from being passed through to div
     // eslint-disable-next-line no-unused-vars
     const { children, className, hasTrigger, ...other } = this.props;
-    const { focusIndex } = this.state;
 
     return (
       <div className={classNames('dqpl-top-bar', className)} {...other}>
-        <ul role="menubar">
-          {Children.map(children, (child, index) =>
-            cloneElement(child, {
-              key: index,
-              onKeyDown: (...args) => {
-                this.onKeyDown(...args);
-
-                if (child.props.onKeyDown) {
-                  child.props.onKeyDown(...args);
-                }
-              },
-              tabIndex: focusIndex === index ? 0 : -1,
-              menuItemRef: menuItem => {
-                this.menuItems[index] = menuItem;
-
-                if (child.props.menuItemRef) {
-                  child.props.menuItemRef(menuItem);
-                }
-              }
-            })
-          )}
-        </ul>
+        <ul role="menubar">{Children.map(children, this.renderChild)}</ul>
       </div>
     );
   }
+
+  renderChild = (child, index) => {
+    const { focusIndex } = this.state;
+
+    if (!child) {
+      return null;
+    }
+
+    return cloneElement(child, {
+      key: index,
+      onKeyDown: (...args) => {
+        this.onKeyDown(...args);
+
+        if (child.props.onKeyDown) {
+          child.props.onKeyDown(...args);
+        }
+      },
+      tabIndex: focusIndex === index ? 0 : -1,
+      menuItemRef: menuItem => {
+        this.menuItems[index] = menuItem;
+
+        if (child.props.menuItemRef) {
+          child.props.menuItemRef(menuItem);
+        }
+      }
+    });
+  };
 }

--- a/test/src/components/TopBar/TopBar.js
+++ b/test/src/components/TopBar/TopBar.js
@@ -92,4 +92,16 @@ test('__TopBar__', t => {
       t.equal(wrapper.state('focusIndex'), 0);
     });
   });
+
+  t.test('supports falsy children', t => {
+    t.plan(1);
+    t.ok(
+      shallow(
+        <TopBar>
+          <div />
+          {false && <div />}
+        </TopBar>
+      )
+    );
+  });
 });


### PR DESCRIPTION
This patch prevents the `<Topbar>` component from trying to "clone" falsy elements.

Closes #72