### PR TITLE
fix: add missing `autoClickLink` prop to MenuItem ts def

### DIFF
--- a/types.d.ts
+++ b/types.d.ts
@@ -48,6 +48,7 @@ interface MenuItemProps extends React.HTMLAttributes<HTMLLIElement> {
   menuItemRef?: RefCallback;
   onClick?: () => void;
   onKeyDown?: (e: React.KeyboardEvent<HTMLLIElement>) => void;
+  autoClickLink?: boolean;
 }
 
 export const MenuItem: React.ComponentType<MenuItemProps>;


### PR DESCRIPTION
Realized I can't use the new prop until it's added to the TS definition.

I should really finish my TypeScript branch...