### PR TITLE
feat: add prop to set arrow positions on first time point out

### DIFF
--- a/__tests__/src/components/FirstTimePointOut/index.js
+++ b/__tests__/src/components/FirstTimePointOut/index.js
@@ -15,6 +15,16 @@ test('handles "noArrow" prop properly', () => {
   expect(ftpo.hasClass('dqpl-no-arrow')).toBeTruthy();
 });
 
+test('handles "arrowPosition" prop', () => {
+  const ftpo = shallow(
+    <FirstTimePointOut arrowPosition="top-right" {...defaults}>
+      {'hello'}
+    </FirstTimePointOut>
+  );
+
+  expect(ftpo.find('.dqpl-arrow.top-right')).toBeTruthy();
+});
+
 test('returns null given a falsey "show" state', () => {
   expect.assertions(1);
   const ftpo = mount(
@@ -40,7 +50,7 @@ test('calls onClose prop when close is clicked', () => {
     </FirstTimePointOut>
   );
 
-  ftpo.find('.dqpl-ftp-dismiss').simulate('click');
+  ftpo.find('.dqpl-ftpo-dismiss').simulate('click');
   expect(called).toBe(true);
 });
 
@@ -53,6 +63,6 @@ test('accepts the dismissText prop', () => {
   );
 
   expect(
-    ftpo.find('.dqpl-ftp-dismiss[aria-label="Fred"]').exists()
+    ftpo.find('.dqpl-ftpo-dismiss[aria-label="Fred"]').exists()
   ).toBeTruthy();
 });

--- a/demo/patterns/components/FirstTimePointOut/index.js
+++ b/demo/patterns/components/FirstTimePointOut/index.js
@@ -6,10 +6,19 @@ const Demo = () => (
   <div>
     <h1>First Time Point Out</h1>
     <h2>Demo</h2>
-    <h3>With Arrow</h3>
+    <h3>With Default Arrow</h3>
     <FirstTimePointOut headerId="ftpo-head" dismissText="Close">
       <h4 id="ftpo-head">First time point out!</h4>
       <p>This is a first time point out with a pointer</p>
+    </FirstTimePointOut>
+    <h3>With Positioned Arrow</h3>
+    <FirstTimePointOut
+      headerId="ftpo-head"
+      dismissText="Close"
+      arrowPosition="top-right"
+    >
+      <h4 id="ftpo-head">First time point out!</h4>
+      <p>This is a first time point out with a positioned pointer</p>
     </FirstTimePointOut>
     <h3>Without Arrow</h3>
     <FirstTimePointOut headerId="ftpo-head-no-arrow" noArrow={true}>
@@ -24,13 +33,19 @@ import { FirstTimePointOut } from 'react-cauldron';
 
 const Demo = () => (
   <section>
-    <FirstTimePointOut headerId={'ftpo-head'}>
-      <h4 id={'ftpo-head'}>First time point out!</h4>
+    <h3>With Default Arrow</h3>
+    <FirstTimePointOut headerId="ftpo-head" dismissText="Close">
+      <h4 id="ftpo-head">First time point out!</h4>
       <p>This is a first time point out with a pointer</p>
     </FirstTimePointOut>
-    <h2>Without Arrow</h2>
-    <FirstTimePointOut headerId={'ftpo-head-no-arrow'} noArrow={true}>
-      <h4 id={'ftpo-head-no-arrow'}>First time point out!</h4>
+    <h3>With Positioned Arrow</h3>
+    <FirstTimePointOut headerId="ftpo-head" dismissText="Close" arrowPosition="top-right">
+      <h4 id="ftpo-head">First time point out!</h4>
+      <p>This is a first time point out with a positioned pointer</p>
+    </FirstTimePointOut>
+    <h3>Without Arrow</h3>
+    <FirstTimePointOut headerId="ftpo-head-no-arrow" noArrow={true}>
+      <h4 id="ftpo-head-no-arrow">First time point out!</h4>
       <p>This is a first time point out without a pointer</p>
     </FirstTimePointOut>
   </section>

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "classnames": "^2.2.5",
     "closest": "0.0.1",
     "css-loader": "^0.28.7",
-    "deque-pattern-library": "^2.5.1",
+    "deque-pattern-library": "^6.1.0",
     "enzyme": "^3.2.0",
     "enzyme-adapter-react-16": "^1.11.2",
     "eslint": "^4.12.1",

--- a/src/components/FirstTimePointOut/index.js
+++ b/src/components/FirstTimePointOut/index.js
@@ -8,6 +8,7 @@ export default class FirstTimePointOut extends Component {
     children: PropTypes.node.isRequired,
     ftpRef: PropTypes.func,
     noArrow: PropTypes.bool,
+    arrowPosition: PropTypes.string,
     onClose: PropTypes.func,
     dismissText: PropTypes.string
   };
@@ -16,7 +17,8 @@ export default class FirstTimePointOut extends Component {
     ftpRef: () => {},
     noArrow: false,
     onClose: () => {},
-    dismissText: 'dismiss'
+    dismissText: 'dismiss',
+    arrowPosition: 'top-left'
   };
 
   constructor() {
@@ -28,7 +30,14 @@ export default class FirstTimePointOut extends Component {
 
   render() {
     const { show } = this.state;
-    const { headerId, ftpRef, children, noArrow, dismissText } = this.props;
+    const {
+      headerId,
+      ftpRef,
+      children,
+      noArrow,
+      dismissText,
+      arrowPosition
+    } = this.props;
 
     if (!show) {
       return null;
@@ -43,14 +52,18 @@ export default class FirstTimePointOut extends Component {
         aria-labelledby={headerId}
       >
         {noArrow ? null : (
-          <div className="dqpl-arrow">
+          <div
+            className={classNames('dqpl-arrow', {
+              [arrowPosition]: !!arrowPosition && !noArrow
+            })}
+          >
             <div className="dqpl-arrow-pointer" />
             <div className="dqpl-arrow-neck" />
           </div>
         )}
         <div className="dqpl-box">
           <button
-            className="dqpl-ftp-dismiss fa fa-close"
+            className="dqpl-ftpo-dismiss fa fa-close"
             type="button"
             aria-label={dismissText}
             onClick={this.onCloseClick}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3360,10 +3360,10 @@ dependency-graph@^0.8.0:
   resolved "https://registry.yarnpkg.com/dependency-graph/-/dependency-graph-0.8.0.tgz#2da2d35ed852ecc24a5d6c17788ba57c3708755b"
   integrity sha512-DCvzSq2UiMsuLnj/9AL484ummEgLtZIcRS7YvtO38QnpX3vqh9nJ8P+zhu8Ja+SmLrBHO2iDbva20jq38qvBkQ==
 
-deque-pattern-library@^2.5.1:
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/deque-pattern-library/-/deque-pattern-library-2.5.1.tgz#614ce776baad2fcad3465c1080d6508229c90176"
-  integrity sha512-ObfjwtKq9ODqdSSXrLHPsLBF8BRnu+DjISCt3nx4bRoa2NtGXPxqI383V+PVVusia0EsqQm0oUETtk4ZOPOAJw==
+deque-pattern-library@^6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/deque-pattern-library/-/deque-pattern-library-6.1.0.tgz#bd22c4e0fac7cd216e0f2161d90a033de2f27b34"
+  integrity sha512-m4zielwGO+byP9PxVwoJeTI2SR8tADVnlFBVCpRBOdcq9MxF+gNsWA0OhsEPP4MYvJrU0extz/pjhQGEWyprCQ==
 
 des.js@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
Added `arrowPosition` prop to `<FirstTimePointOut />` component to allow arrow positions [via the deque pattern library](https://pattern-library.dequelabs.com/components/first-time-point).

Ref: #54 