### PR TITLE
feat: add onSelect func prop to OptionsMenu

### DIFF
--- a/__tests__/typechecks.tsx
+++ b/__tests__/typechecks.tsx
@@ -129,7 +129,7 @@ const options = () => (
     >
       hi
     </OptionsMenuTrigger>
-    <OptionsMenu onClose={noop} id="id" show>
+    <OptionsMenu onClose={noop} onSelect={noop} id="id" show>
       <OptionsMenuItem>hi</OptionsMenuItem>
     </OptionsMenu>
   </OptionsMenuWrapper>

--- a/src/components/OptionsMenu/OptionsMenu.js
+++ b/src/components/OptionsMenu/OptionsMenu.js
@@ -6,18 +6,22 @@ export default class OptionsMenu extends Component {
     children: PropTypes.node.isRequired,
     id: PropTypes.string.isRequired,
     onClose: PropTypes.func.isRequired,
+    onSelect: PropTypes.func,
     show: PropTypes.bool
   };
 
   static defaultProps = {
-    show: false
+    show: false,
+    onSelect: () => {}
   };
 
   constructor() {
     super();
     this.itemRefs = [];
     this.state = { itemIndex: 0 };
-    this.onKeyDown = this.onKeyDown.bind(this);
+    this.handleKeyDown = this.handleKeyDown.bind(this);
+    this.handleClick = this.handleClick.bind(this);
+    this.menuRef = React.createRef();
   }
 
   componentDidUpdate(prevProps, prevState) {
@@ -53,16 +57,24 @@ export default class OptionsMenu extends Component {
         aria-expanded={show}
         id={id}
         role="menu"
-        onKeyDown={this.onKeyDown}
+        onClick={this.handleClick}
+        onKeyDown={this.handleKeyDown}
+        ref={this.menuRef}
       >
         {items}
       </ul>
     );
   }
 
-  onKeyDown(e) {
-    const { which, target } = e;
+  handleClick(e) {
+    const { menuRef, props } = this;
+    if (menuRef.current && menuRef.current.contains(e.target)) {
+      props.onSelect(e);
+    }
+  }
 
+  handleKeyDown(e) {
+    const { which, target } = e;
     switch (which) {
       // up / down
       case 38:

--- a/types.d.ts
+++ b/types.d.ts
@@ -182,6 +182,7 @@ interface OptionsMenuProps {
   children: React.ReactNode;
   id: string;
   onClose: () => void;
+  onSelect: (e: React.MouseEvent<HTMLElement>) => void;
   show?: boolean;
 }
 

--- a/types.d.ts
+++ b/types.d.ts
@@ -182,7 +182,7 @@ interface OptionsMenuProps {
   children: React.ReactNode;
   id: string;
   onClose: () => void;
-  onSelect: (e: React.MouseEvent<HTMLElement>) => void;
+  onSelect?: (e: React.MouseEvent<HTMLElement>) => void;
   show?: boolean;
 }
 


### PR DESCRIPTION
`<OptionsMenu>` now has an `onSelect` prop that passes the event for the element that was selected.

Ref: #58 