### PR TITLE
feat: add ClickOutsideListener component to capture outside of children events

### DIFF
--- a/__tests__/src/components/ClickOutsideListener/index.js
+++ b/__tests__/src/components/ClickOutsideListener/index.js
@@ -195,6 +195,20 @@ test('should remove event listeners when props change', () => {
   expect(onClickOutside).not.toBeCalled();
 });
 
+test('should not remove event listeners when event props do not change', () => {
+  const removeEventListeners = jest.fn();
+  const onClickOutside = () => {};
+  const wrapper = mount(
+    <ClickOutsideListener onClickOutside={noop} mouseEvent="click">
+      <div>bar</div>
+    </ClickOutsideListener>
+  );
+  wrapper.instance().removeEventListeners = removeEventListeners;
+  wrapper.setProps({ onClickOutside });
+
+  expect(removeEventListeners).not.toBeCalled();
+});
+
 test('should not call `onClickOutside` when event is prevented', () => {
   const onClickOutside = jest.fn();
   mount(

--- a/__tests__/src/components/ClickOutsideListener/index.js
+++ b/__tests__/src/components/ClickOutsideListener/index.js
@@ -1,0 +1,215 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import ClickOutsideListener from 'src/components/ClickOutsideListener';
+
+const noop = () => {};
+
+let wrapperNode;
+let mountNode;
+
+beforeEach(() => {
+  wrapperNode = document.createElement('div');
+  wrapperNode.innerHTML = `
+    <a href="#foo" data-test>Click Me!</a>
+    <div id="#mount"></div>
+  `;
+  document.body.appendChild(wrapperNode);
+  mountNode = document.getElementById('mount');
+});
+
+afterEach(() => {
+  document.body.innerHTML = '';
+  wrapperNode = null;
+  mountNode = null;
+});
+
+test('renders children', () => {
+  const children = <div>Hello World</div>;
+  const wrapper = mount(
+    <ClickOutsideListener onClickOutside={noop}>
+      <div>Hello World</div>
+    </ClickOutsideListener>
+  );
+
+  expect(wrapper.contains(children)).toBe(true);
+});
+
+test('should call `onClickOutside` when clicked outside', () => {
+  const onClickOutside = jest.fn();
+  mount(
+    <ClickOutsideListener onClickOutside={onClickOutside}>
+      <div>bar</div>
+    </ClickOutsideListener>,
+    { attachTo: mountNode }
+  );
+
+  wrapperNode
+    .querySelector('a')
+    .dispatchEvent(new Event('click', { bubbles: true }));
+
+  expect(onClickOutside).toBeCalled();
+});
+
+test('should not call `onClickOutside` when clicked inside', () => {
+  const onClickOutside = jest.fn();
+  const wrapper = mount(
+    <ClickOutsideListener onClickOutside={onClickOutside}>
+      <div data-test>Click me!</div>
+    </ClickOutsideListener>
+  );
+
+  wrapper.find('[data-test]').simulate('click');
+
+  expect(onClickOutside).not.toBeCalled();
+});
+
+test('should call `onClickOutside` with event', () => {
+  const onClickOutside = jest.fn();
+  mount(
+    <ClickOutsideListener onClickOutside={onClickOutside}>
+      <div>bar</div>
+    </ClickOutsideListener>,
+    { attachTo: mountNode }
+  );
+
+  let testNode = wrapperNode.querySelector('[data-test]');
+  let event = new Event('click', { bubbles: true });
+  testNode.dispatchEvent(event);
+
+  expect(onClickOutside).toBeCalledWith(event);
+});
+
+test('should allow `mouseEvent` to be changed', () => {
+  const onClickOutside = jest.fn();
+  mount(
+    <ClickOutsideListener
+      onClickOutside={onClickOutside}
+      mouseEvent="mousedown"
+    >
+      <div>bar</div>
+    </ClickOutsideListener>,
+    { attachTo: mountNode }
+  );
+
+  wrapperNode
+    .querySelector('[data-test]')
+    .dispatchEvent(new Event('mousedown', { bubbles: true }));
+
+  expect(onClickOutside).toBeCalled();
+});
+
+test('should allow `mouseEvent` to be false', () => {
+  const onClickOutside = jest.fn();
+  mount(
+    <ClickOutsideListener onClickOutside={onClickOutside} mouseEvent={false}>
+      <div>bar</div>
+    </ClickOutsideListener>,
+    { attachTo: mountNode }
+  );
+
+  wrapperNode
+    .querySelector('[data-test]')
+    .dispatchEvent(new Event('click', { bubbles: true }));
+
+  expect(onClickOutside).not.toBeCalled();
+});
+
+test('should call `onClickOutside` when touched outside', () => {
+  const onClickOutside = jest.fn();
+  mount(
+    <ClickOutsideListener onClickOutside={onClickOutside}>
+      <div>bar</div>
+    </ClickOutsideListener>,
+    { attachTo: mountNode }
+  );
+
+  wrapperNode
+    .querySelector('[data-test]')
+    .dispatchEvent(new Event('touchend', { bubbles: true }));
+
+  expect(onClickOutside).toHaveBeenCalledTimes(1);
+});
+
+test('should not call `onClickOutside` when touched inside', () => {
+  const onClickOutside = jest.fn();
+  const wrapper = mount(
+    <ClickOutsideListener onClickOutside={onClickOutside}>
+      <div data-test>Touch me!</div>
+    </ClickOutsideListener>
+  );
+
+  wrapper.find('[data-test]').simulate('touchend');
+
+  expect(onClickOutside).not.toBeCalled();
+});
+
+test('should allow `touchEvent` to be changed', () => {
+  const onClickOutside = jest.fn();
+  mount(
+    <ClickOutsideListener
+      onClickOutside={onClickOutside}
+      touchEvent="touchstart"
+    >
+      <div>bar</div>
+    </ClickOutsideListener>,
+    { attachTo: mountNode }
+  );
+
+  wrapperNode
+    .querySelector('[data-test]')
+    .dispatchEvent(new Event('touchstart', { bubbles: true }));
+
+  expect(onClickOutside).toBeCalled();
+});
+
+test('should allow `touchEvent` to be false', () => {
+  const onClickOutside = jest.fn();
+  mount(
+    <ClickOutsideListener onClickOutside={onClickOutside} touchEvent={false}>
+      <div>bar</div>
+    </ClickOutsideListener>,
+    { attachTo: mountNode }
+  );
+
+  wrapperNode
+    .querySelector('[data-test]')
+    .dispatchEvent(new Event('touchend', { bubbles: true }));
+
+  expect(onClickOutside).not.toBeCalled();
+});
+
+test('should remove event listeners when props change', () => {
+  const onClickOutside = jest.fn();
+  const wrapper = mount(
+    <ClickOutsideListener onClickOutside={onClickOutside}>
+      <div>bar</div>
+    </ClickOutsideListener>,
+    { attachTo: mountNode }
+  );
+
+  wrapper.setProps({ mouseEvent: false });
+  wrapperNode
+    .querySelector('[data-test]')
+    .dispatchEvent(new Event('click'), { bubbles: true });
+
+  expect(onClickOutside).not.toBeCalled();
+});
+
+test('should not call `onClickOutside` when event is prevented', () => {
+  const onClickOutside = jest.fn();
+  mount(
+    <ClickOutsideListener onClickOutside={onClickOutside}>
+      <div>bar</div>
+    </ClickOutsideListener>,
+    { attachTo: mountNode }
+  );
+
+  document.body.addEventListener('click', event => event.preventDefault());
+
+  let testNode = wrapperNode.querySelector('[data-test]');
+  testNode.dispatchEvent(
+    new Event('click', { bubbles: true, cancelable: true })
+  );
+
+  expect(onClickOutside).not.toBeCalled();
+});

--- a/__tests__/src/components/Modal/index.js
+++ b/__tests__/src/components/Modal/index.js
@@ -39,46 +39,54 @@ test('focuses heading when "show" prop is updated from falsey to truthy', done =
 });
 
 test('calls onClose when a "show" prop is updated from truthy to falsey', () => {
-  let called = false;
+  let onClose = jest.fn();
   const modal = mount(
-    <Modal {...defaults} show={true} onClose={() => (called = true)}>
+    <Modal {...defaults} show={true} onClose={onClose}>
       {'hello'}
     </Modal>
   );
 
   modal.setProps({ show: false });
-  expect(called).toBe(true);
+  expect(onClose).toBeCalled();
+});
+
+test('calls onClose when clicked outside', () => {
+  let onClose = jest.fn();
+  const modal = mount(
+    <Modal {...defaults} show={true} onClose={onClose}>
+      {'hello'}
+    </Modal>
+  );
+
+  modal.instance().handleClickOutside();
+
+  expect(onClose).toBeCalled();
 });
 
 test('supports the "modalRef" prop', () => {
-  let called = false;
+  let called = jest.fn();
   expect.assertions(1);
-  const modalRef = () => (called = true);
+  const modalRef = called;
   const modal = mount(
     <Modal {...defaults} show={true} modalRef={modalRef}>
       {'Hi'}
     </Modal>
   );
-  expect(called).toBeTruthy();
+  expect(called).toBeCalled();
   modal.unmount();
 });
 
 test('passes additional props through to dialog element', () => {
-  let called = false;
+  let onKeyDown = jest.fn();
   const modal = mount(
-    <Modal
-      {...defaults}
-      show={true}
-      data-foo="true"
-      onKeyDown={() => (called = true)}
-    >
+    <Modal {...defaults} show={true} data-foo="true" onKeyDown={onKeyDown}>
       {'hi'}
     </Modal>
   );
 
   modal.find('[role="dialog"]').simulate('keydown', { which: 9 });
 
-  expect(called).toBeTruthy();
+  expect(onKeyDown).toBeCalled();
   expect(modal.find('[data-foo="true"]').exists()).toBeTruthy();
 });
 

--- a/__tests__/src/components/OptionsMenu/OptionsMenu.js
+++ b/__tests__/src/components/OptionsMenu/OptionsMenu.js
@@ -109,6 +109,19 @@ test('calls onClose given a tab keydown', () => {
   expect(onClose).toBeCalled();
 });
 
+test('calls onClose when clicked outside', () => {
+  let onClose = jest.fn();
+  const wrapper = mount(
+    <OptionsMenu {...defaultProps} show={true} onClose={onClose}>
+      <li>option 1</li>
+      <li>option 2</li>
+    </OptionsMenu>
+  );
+  wrapper.instance().handleClickOutside();
+
+  expect(onClose).toBeCalled();
+});
+
 test('handles enter / space keydowns', () => {
   expect.assertions(1);
   let clickHandler = jest.fn();

--- a/__tests__/src/components/SideBar/index.js
+++ b/__tests__/src/components/SideBar/index.js
@@ -57,12 +57,23 @@ test('handles DOWN arrow', () => {
 
 test('handles escape (calls onDismiss)', () => {
   expect.assertions(1);
-  let called = false;
-  const wrapper = mountWrapper(() => (called = true));
+  let onDismiss = jest.fn();
+  const wrapper = mountWrapper(onDismiss);
 
   const e = { which: 27 };
   wrapper.instance().onKeyDown(e);
-  expect(called).toBeTruthy();
+  expect(onDismiss).toBeCalled();
+});
+
+test('calls onDismiss when clicked outside', () => {
+  let onDismiss = jest.fn();
+  const wrapper = mountWrapper(onDismiss);
+  wrapper.setState({ wide: false });
+  wrapper.setProps({ show: true });
+
+  wrapper.instance().handleClickOutside();
+
+  expect(onDismiss).toBeCalled();
 });
 
 test('animates / toggles display given a show prop change', done => {

--- a/__tests__/typechecks.tsx
+++ b/__tests__/typechecks.tsx
@@ -29,7 +29,8 @@ import {
   Workspace,
   AriaIsolate,
   focusableSelector,
-  TextField
+  TextField,
+  ClickOutsideListener
 } from '../types';
 
 const noop = () => {};
@@ -229,3 +230,13 @@ const textField = () => (
     aria-describedby="help-text"
   />
 );
+
+const clickOutside = () => {
+  <ClickOutsideListener
+    onClickOutside={noopEventHandler}
+    mouseEvent="click"
+    touchEvent="touchend"
+  >
+    <div>foo</div>
+  </ClickOutsideListener>;
+};

--- a/demo/index.js
+++ b/demo/index.js
@@ -18,6 +18,7 @@ import Checkbox from './patterns/components/Checkbox';
 import Tooltip from './patterns/components/Tooltip';
 import Card from './patterns/components/Card';
 import TextField from './patterns/components/TextField';
+import ClickOutsideListener from './patterns/components/ClickOutsideListener';
 
 // import cauldron react components
 import {
@@ -137,6 +138,12 @@ class App extends Component {
               {this.renderSideBarLink('/components/checkbox', 'Checkbox')}
             </MenuItem>
             <MenuItem>
+              {this.renderSideBarLink(
+                '/components/clickoutside',
+                'Click Outside Listener'
+              )}
+            </MenuItem>
+            <MenuItem>
               {this.renderSideBarLink('/components/tooltip', 'Tooltip')}
             </MenuItem>
             <MenuItem>
@@ -176,6 +183,11 @@ class App extends Component {
                 component={RadioGroup}
               />
               <Route exact path="/components/checkbox" component={Checkbox} />
+              <Route
+                exact
+                path="/components/clickoutside"
+                component={ClickOutsideListener}
+              />
               <Route exact path="/components/tooltip" component={Tooltip} />
               <Route exact path="/components/card" component={Card} />
               <Route

--- a/demo/patterns/components/ClickOutsideListener/index.js
+++ b/demo/patterns/components/ClickOutsideListener/index.js
@@ -1,0 +1,32 @@
+import React from 'react';
+import Highlight from '../../../Highlight';
+import { ClickOutsideListener } from 'src/';
+
+const Demo = () => (
+  <div>
+    <h1>Click Outside Listener</h1>
+    <h2>Demo</h2>
+    <ClickOutsideListener
+      onClickOutside={() => alert('You clicked outside of me.')}
+    >
+      <button type="button" className="dqpl-button-primary">
+        Click Inside
+      </button>
+    </ClickOutsideListener>
+    <h2>Code Sample</h2>
+    <Highlight language="javascript">
+      {`
+import React from 'react';
+import { ClickOutsideListener } from 'cauldron-react';
+
+const Demo = () => (
+  <ClickOutsideListener onClickOutside={() => alert('You clicked outside of me.')}>
+    <button type="button" className="dqpl-button-primary">Click Inside</button>
+  </ClickOutsideListener>
+);
+      `}
+    </Highlight>
+  </div>
+);
+
+export default Demo;

--- a/demo/patterns/components/OptionsMenu/index.js
+++ b/demo/patterns/components/OptionsMenu/index.js
@@ -110,7 +110,8 @@ class Demo extends Component {
     );
   }
 
-  toggleMenu() {
+  toggleMenu(e) {
+    e && e.preventDefault();
     this.setState(({ show }) => ({
       show: !show
     }));

--- a/src/components/ClickOutsideListener/index.js
+++ b/src/components/ClickOutsideListener/index.js
@@ -1,0 +1,82 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+export default class ClickOutsideListener extends React.Component {
+  static propTypes = {
+    children: PropTypes.node.isRequired,
+    onClickOutside: PropTypes.func.isRequired,
+    mouseEvent: PropTypes.oneOf(['mousedown', 'click', 'mouseup', false]),
+    touchEvent: PropTypes.oneOf(['touchstart', 'touchend', false])
+  };
+
+  static defaultProps = {
+    mouseEvent: 'click',
+    touchEvent: 'touchend'
+  };
+
+  handleEvent = event => {
+    const { nodeRef, props } = this;
+    const { onClickOutside } = props;
+
+    if (event.defaultPrevented) {
+      return;
+    }
+
+    if (nodeRef && !nodeRef.contains(event.target)) {
+      onClickOutside(event);
+    }
+  };
+
+  componentDidMount() {
+    this.attachEventListeners();
+  }
+
+  componentDidUpdate(prevProps) {
+    const { mouseEvent, touchEvent } = this;
+    if (
+      prevProps.mouseEvent !== mouseEvent ||
+      prevProps.touchEvent !== touchEvent
+    ) {
+      this.removeEventListeners(prevProps.mouseEvent, prevProps.touchEvent);
+      this.attachEventListeners();
+    }
+  }
+
+  componentWillUnmount() {
+    const { mouseEvent, touchEvent } = this.props;
+    this.removeEventListeners(mouseEvent, touchEvent);
+  }
+
+  attachEventListeners = () => {
+    const { mouseEvent, touchEvent } = this.props;
+    typeof mouseEvent === 'string' &&
+      document.addEventListener(mouseEvent, this.handleEvent);
+    typeof touchEvent === 'string' &&
+      document.addEventListener(touchEvent, this.handleEvent);
+  };
+
+  removeEventListeners = (mouseEvent, touchEvent) => {
+    typeof mouseEvent === 'string' &&
+      document.removeEventListener(mouseEvent, this.handleEvent);
+    typeof touchEvent === 'string' &&
+      document.removeEventListener(touchEvent, this.handleEvent);
+  };
+
+  resolveRef = node => {
+    this.nodeRef = node;
+
+    // If child has its own ref, we want to update
+    // its ref with the newly cloned node
+    let { ref } = this.props.children;
+    if (typeof ref === 'function') {
+      ref(node);
+    } else if (ref !== null) {
+      ref.current = node;
+    }
+  };
+
+  render() {
+    const { props, resolveRef } = this;
+    return React.cloneElement(props.children, { ref: resolveRef });
+  }
+}

--- a/src/components/ClickOutsideListener/index.js
+++ b/src/components/ClickOutsideListener/index.js
@@ -32,7 +32,7 @@ export default class ClickOutsideListener extends React.Component {
   }
 
   componentDidUpdate(prevProps) {
-    const { mouseEvent, touchEvent } = this;
+    const { mouseEvent, touchEvent } = this.props;
     if (
       prevProps.mouseEvent !== mouseEvent ||
       prevProps.touchEvent !== touchEvent

--- a/src/components/Modal/index.js
+++ b/src/components/Modal/index.js
@@ -4,6 +4,7 @@ import classNames from 'classnames';
 import FocusTrap from 'focus-trap-react';
 import Offscreen from '../Offscreen';
 import Scrim from '../Scrim';
+import ClickOutsideListener from '../ClickOutsideListener';
 import AriaIsolate from '../../utils/aria-isolate';
 
 const noop = () => {};
@@ -22,6 +23,7 @@ export default class Modal extends Component {
 
     this.close = this.close.bind(this);
     this.focusHeading = this.focusHeading.bind(this);
+    this.handleClickOutside = this.handleClickOutside.bind(this);
   }
 
   componentDidMount() {
@@ -83,32 +85,34 @@ export default class Modal extends Component {
           fallbackFocus: '.dqpl-modal-heading'
         }}
       >
-        <div
-          role="dialog"
-          className={classNames('dqpl-modal', className, {
-            'dqpl-dialog-show': show
-          })}
-          ref={el => {
-            this.element = el;
-            modalRef(el);
-          }}
-          {...other}
-        >
-          <div className="dqpl-dialog-inner">
-            <div className="dqpl-modal-header">
-              <Heading
-                className="dqpl-modal-heading"
-                ref={el => (this.heading = el)}
-                tabIndex={-1}
-              >
-                {heading.text}
-              </Heading>
-              {close}
+        <ClickOutsideListener onClickOutside={this.handleClickOutside}>
+          <div
+            role="dialog"
+            className={classNames('dqpl-modal', className, {
+              'dqpl-dialog-show': show
+            })}
+            ref={el => {
+              this.element = el;
+              modalRef(el);
+            }}
+            {...other}
+          >
+            <div className="dqpl-dialog-inner">
+              <div className="dqpl-modal-header">
+                <Heading
+                  className="dqpl-modal-heading"
+                  ref={el => (this.heading = el)}
+                  tabIndex={-1}
+                >
+                  {heading.text}
+                </Heading>
+                {close}
+              </div>
+              {children}
             </div>
-            {children}
           </div>
-          <Scrim show={show} />
-        </div>
+        </ClickOutsideListener>
+        <Scrim show={show} />
       </FocusTrap>
     );
   }
@@ -116,6 +120,13 @@ export default class Modal extends Component {
   close() {
     this.state.isolator.deactivate();
     this.props.onClose();
+  }
+
+  handleClickOutside() {
+    const { show, forceAction } = this.props;
+    if (show && !forceAction) {
+      this.close();
+    }
   }
 
   focusHeading() {

--- a/src/components/OptionsMenu/OptionsMenu.js
+++ b/src/components/OptionsMenu/OptionsMenu.js
@@ -86,9 +86,9 @@ export default class OptionsMenu extends Component {
   }
 
   handleClickOutside() {
-    const { show, props } = this;
-    if (!show) {
-      props.onClose();
+    const { show, onClose } = this.props;
+    if (show) {
+      onClose();
     }
   }
 

--- a/src/components/OptionsMenu/OptionsMenu.js
+++ b/src/components/OptionsMenu/OptionsMenu.js
@@ -1,5 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
+import ClickOutsideListener from '../ClickOutsideListener';
 
 export default class OptionsMenu extends Component {
   static propTypes = {
@@ -21,6 +22,7 @@ export default class OptionsMenu extends Component {
     this.state = { itemIndex: 0 };
     this.handleKeyDown = this.handleKeyDown.bind(this);
     this.handleClick = this.handleClick.bind(this);
+    this.handleClickOutside = this.handleClickOutside.bind(this);
     this.menuRef = React.createRef();
   }
 
@@ -51,18 +53,20 @@ export default class OptionsMenu extends Component {
     ));
 
     return (
-      <ul
-        {...other}
-        className="dqpl-options-menu"
-        aria-expanded={show}
-        id={id}
-        role="menu"
-        onClick={this.handleClick}
-        onKeyDown={this.handleKeyDown}
-        ref={this.menuRef}
-      >
-        {items}
-      </ul>
+      <ClickOutsideListener onClickOutside={this.handleClickOutside}>
+        <ul
+          {...other}
+          className="dqpl-options-menu"
+          aria-expanded={show}
+          id={id}
+          role="menu"
+          onClick={this.handleClick}
+          onKeyDown={this.handleKeyDown}
+          ref={this.menuRef}
+        >
+          {items}
+        </ul>
+      </ClickOutsideListener>
     );
   }
 
@@ -70,6 +74,13 @@ export default class OptionsMenu extends Component {
     const { menuRef, props } = this;
     if (menuRef.current && menuRef.current.contains(e.target)) {
       props.onSelect(e);
+    }
+  }
+
+  handleClickOutside() {
+    const { show, props } = this;
+    if (!show) {
+      props.onClose();
     }
   }
 

--- a/src/components/SideBar/index.js
+++ b/src/components/SideBar/index.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import keyname from 'keyname';
 import Scrim from '../Scrim';
+import ClickOutsideListener from '../ClickOutsideListener';
 import { isWide } from '../../utils/viewport';
 
 export default class SideBar extends Component {
@@ -24,6 +25,7 @@ export default class SideBar extends Component {
     super();
     this.onKeyDown = this.onKeyDown.bind(this);
     this.onResize = this.onResize.bind(this);
+    this.handleClickOutside = this.handleClickOutside.bind(this);
     this.state = {
       focusIndex: 0,
       wide: isWide()
@@ -81,6 +83,13 @@ export default class SideBar extends Component {
     }
   }
 
+  handleClickOutside() {
+    let { show, onDismiss } = this.props;
+    if (show && !this.state.wide) {
+      onDismiss();
+    }
+  }
+
   componentDidUpdate(prevProps) {
     const { show } = this.props;
 
@@ -122,20 +131,22 @@ export default class SideBar extends Component {
 
     return (
       <Fragment>
-        <ul
-          role="menu"
-          className={classNames('dqpl-side-bar', className, animateClass)}
-          {...listProps}
-        >
-          {Children.map(children, (child, index) =>
-            cloneElement(child, {
-              key: index,
-              onKeyDown: this.onKeyDown,
-              tabIndex: focusIndex === index ? 0 : -1,
-              menuItemRef: menuItem => (this.menuItems[index] = menuItem)
-            })
-          )}
-        </ul>
+        <ClickOutsideListener onClickOutside={this.handleClickOutside}>
+          <ul
+            role="menu"
+            className={classNames('dqpl-side-bar', className, animateClass)}
+            {...listProps}
+          >
+            {Children.map(children, (child, index) =>
+              cloneElement(child, {
+                key: index,
+                onKeyDown: this.onKeyDown,
+                tabIndex: focusIndex === index ? 0 : -1,
+                menuItemRef: menuItem => (this.menuItems[index] = menuItem)
+              })
+            )}
+          </ul>
+        </ClickOutsideListener>
         <Scrim show={!wide && show} />
       </Fragment>
     );

--- a/src/index.js
+++ b/src/index.js
@@ -36,6 +36,7 @@ export {
   CardFooter
 } from './components/Card';
 export TextField from './components/TextField';
+export ClickOutsideListener from './components/ClickOutsideListener';
 /**
  * Helpers / Utils
  */

--- a/types.d.ts
+++ b/types.d.ts
@@ -295,3 +295,16 @@ interface TextFieldProps {
 }
 
 export const TextField: React.ComponentType<TextFieldProps>;
+
+interface ClickOutsideListenerProps {
+  children: React.ReactNode;
+  onClickOutside: (
+    e: React.MouseEvent<HTMLElement> | React.TouchEvent<HTMLElement>
+  ) => void;
+  mouseEvent?: 'mousedown' | 'click' | 'mouseup' | false;
+  touchEvent?: 'touchstart' | 'touchend' | false;
+}
+
+export const ClickOutsideListener: React.ComponentType<
+  ClickOutsideListenerProps
+>;


### PR DESCRIPTION
* New Component: `<ClickOutsideListener />`
* Has `onClickOutside` prop to allow actions to handle `click`/`touch` events outside of children
* Set event to listen to (i.e. `mouseup`, `touchstart`) with `mouse/touchEvent` prop or set to `false` to prevent completely

Evaluated both [tj/react-click-outside](https://github.com/tj/react-click-outside) and [airbnb/react-outside-click-handler](https://github.com/airbnb/react-outside-click-handler). The former is only available from GitHub and mounts to an empty `<div>` which seems undesirable. The latter is nearly [10kb min + gzipped](https://bundlephobia.com/result?p=react-outside-click-handler@1.2.3) which seems extremely undesirable for such a small component.

Ref: #57 

Closes: #84 