### PR TITLE
feat: add closeOnSelect prop to OptionsMenu

### DIFF
--- a/__tests__/src/components/OptionsMenu/OptionsMenu.js
+++ b/__tests__/src/components/OptionsMenu/OptionsMenu.js
@@ -198,3 +198,54 @@ test('fires onSelect when menu item is selected with enter', () => {
     expect.objectContaining({ target: itemNode })
   );
 });
+
+test('fires onClose when menu item is selected', () => {
+  const onClose = jest.fn();
+  const wrapper = mount(
+    <OptionsMenu {...defaultProps} onClose={onClose}>
+      <li>option 1</li>
+      <li>option 2</li>
+    </OptionsMenu>
+  );
+
+  wrapper
+    .find('li')
+    .at(0)
+    .simulate('click');
+
+  expect(onClose).toBeCalled();
+});
+
+test('does not fire onClose when menu item is selected and default prevented', () => {
+  const onClose = jest.fn();
+  const wrapper = mount(
+    <OptionsMenu {...defaultProps} onClose={onClose}>
+      <li>option 1</li>
+      <li>option 2</li>
+    </OptionsMenu>
+  );
+
+  wrapper
+    .find('li')
+    .at(0)
+    .simulate('click', { defaultPrevented: true });
+
+  expect(onClose).not.toBeCalled();
+});
+
+test('does not fire onClose when menu item is selected and closeOnSelect is false', () => {
+  const onClose = jest.fn();
+  const wrapper = mount(
+    <OptionsMenu {...defaultProps} onClose={onClose} closeOnSelect={false}>
+      <li>option 1</li>
+      <li>option 2</li>
+    </OptionsMenu>
+  );
+
+  wrapper
+    .find('li')
+    .at(0)
+    .simulate('click');
+
+  expect(onClose).not.toBeCalled();
+});

--- a/__tests__/typechecks.tsx
+++ b/__tests__/typechecks.tsx
@@ -129,7 +129,7 @@ const options = () => (
     >
       hi
     </OptionsMenuTrigger>
-    <OptionsMenu onClose={noop} onSelect={noop} id="id" show>
+    <OptionsMenu onClose={noop} onSelect={noop} id="id" show closeOnSelect>
       <OptionsMenuItem>hi</OptionsMenuItem>
     </OptionsMenu>
   </OptionsMenuWrapper>

--- a/src/components/OptionsMenu/OptionsMenu.js
+++ b/src/components/OptionsMenu/OptionsMenu.js
@@ -7,11 +7,13 @@ export default class OptionsMenu extends Component {
     id: PropTypes.string.isRequired,
     onClose: PropTypes.func.isRequired,
     onSelect: PropTypes.func,
-    show: PropTypes.bool
+    show: PropTypes.bool,
+    closeOnSelect: PropTypes.bool
   };
 
   static defaultProps = {
     show: false,
+    closeOnSelect: true,
     onSelect: () => {}
   };
 
@@ -38,7 +40,8 @@ export default class OptionsMenu extends Component {
   }
 
   render() {
-    const { children, id, show, ...other } = this.props;
+    // eslint-disable-next-line no-unused-vars
+    const { children, id, show, closeOnSelect, ...other } = this.props;
     const items = children.map(({ props }, i) => (
       <li
         key={`${id}-${i}`}
@@ -68,8 +71,13 @@ export default class OptionsMenu extends Component {
 
   handleClick(e) {
     const { menuRef, props } = this;
+    const { onSelect, onClose } = props;
     if (menuRef.current && menuRef.current.contains(e.target)) {
-      props.onSelect(e);
+      if (!e.defaultPrevented && props.closeOnSelect) {
+        onClose();
+      }
+
+      onSelect(e);
     }
   }
 

--- a/types.d.ts
+++ b/types.d.ts
@@ -183,6 +183,7 @@ interface OptionsMenuProps {
   id: string;
   onClose: () => void;
   onSelect?: (e: React.MouseEvent<HTMLElement>) => void;
+  closeOnSelect?: boolean;
   show?: boolean;
 }
 


### PR DESCRIPTION
New prop `closeOnSelect` added to `<OptionsMenu />`.

I set the default to be `true` since it seems to be more common that you would want to close the menu than not. This behavior can be opted out of across the menu by setting it to `false` _or_ by preventing the default event.

Ref: #59 