### PR TITLE
docs: Remove unfriendly disclaimer message

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # Cauldron React
 
-This project is used internally by Deque Systems and is only updated when Deque needs changes for our internal use. You are free to use this project and to learn from the patterns and techniques that we used to make the widgets accessible. However we do not intend to respond to questions, feature requests, fix bugs or integrate external pull requests unless we find ourselves sitting around one day with nothing better to do. We promise, in return, not to submit questions, feature requests, bugs and pull requests to your internal projects.
-
 [![CircleCI](https://circleci.com/gh/dequelabs/cauldron-react.svg?style=svg)](https://circleci.com/gh/dequelabs/cauldron-react)
 
 ## Installation


### PR DESCRIPTION
This patch removes the extremely unfriendly/unwelcoming message about this project. I don't know why it's here and feel that it's the wrong direction we should be taking our OSS repositories.

I'm happy to take on the responsibility of answering questions, addressing feature requests and looking at bug reports if everyone else is "too busy" to do so.