### PR TITLE
fix: push state upwards in Toast and refactor deprecated method

### DIFF
--- a/__tests__/src/components/Toast/index.js
+++ b/__tests__/src/components/Toast/index.js
@@ -48,7 +48,9 @@ test('handles transition from falsey show to truthy show prop', done => {
   expect(wrapper.find('.dqpl-toast').hasClass('dqpl-fadein-setup')).toBeFalsy();
 
   wrapper.setProps({ show: true });
+
   setTimeout(() => {
+    wrapper.update();
     expect(
       wrapper.find('.dqpl-toast').hasClass('dqpl-fadein-setup')
     ).toBeTruthy();
@@ -62,6 +64,7 @@ test('handles transition from truthy show to falsey show prop', done => {
       {'hi'}
     </Toast>
   );
+  expect(wrapper.find('.dqpl-toast').hasClass('dqpl-hidden')).toBeFalsy();
   wrapper.setProps({ show: false });
 
   setTimeout(() => {

--- a/demo/patterns/components/Toast/index.js
+++ b/demo/patterns/components/Toast/index.js
@@ -11,7 +11,7 @@ export default class Demo extends Component {
   }
 
   onTriggerClick(nextType) {
-    this.setState({ nextType });
+    this.setState({ type: null, nextType });
   }
 
   onToastDismiss() {
@@ -27,8 +27,8 @@ export default class Demo extends Component {
   }
 
   componentDidUpdate(prevProps, prevState) {
-    const { nextType, type } = this.state;
-    if (nextType && nextType !== type && nextType !== prevState.nextType) {
+    const { nextType } = this.state;
+    if (nextType && nextType !== prevState.nextType) {
       this.setState({ type: nextType });
     }
   }

--- a/demo/patterns/components/Toast/index.js
+++ b/demo/patterns/components/Toast/index.js
@@ -10,12 +10,12 @@ export default class Demo extends Component {
     this.onToastDismiss = this.onToastDismiss.bind(this);
   }
 
-  onTriggerClick(type) {
-    this.setState({ type });
+  onTriggerClick(nextType) {
+    this.setState({ nextType });
   }
 
   onToastDismiss() {
-    const { type } = this.state;
+    const { type, nextType } = this.state;
     const trigger = this[type];
 
     // return focus back to the dismissed toast's trigger
@@ -23,7 +23,14 @@ export default class Demo extends Component {
       trigger.focus();
     }
 
-    this.setState({ type: null });
+    this.setState({ type: nextType ? nextType : null, nextType: null });
+  }
+
+  componentDidUpdate(prevProps, prevState) {
+    const { nextType, type } = this.state;
+    if (nextType && nextType !== type && nextType !== prevState.nextType) {
+      this.setState({ type: nextType });
+    }
   }
 
   render() {

--- a/src/components/Toast/index.js
+++ b/src/components/Toast/index.js
@@ -39,8 +39,7 @@ export default class Toast extends Component {
     super(props);
 
     this.state = {
-      animationClass: props.show ? 'dqpl-fadein-setup' : 'dqpl-hidden',
-      destroy: !props.show
+      animationClass: props.show ? 'dqpl-fadein-setup' : 'dqpl-hidden'
     };
 
     this.dismissToast = this.dismissToast.bind(this);
@@ -48,10 +47,9 @@ export default class Toast extends Component {
   }
 
   componentDidMount() {
-    const { destroy } = this.state;
-    const { autoHide } = this.props;
+    const { autoHide, show } = this.props;
 
-    if (!destroy) {
+    if (show) {
       // Timeout because CSS display: none/block and opacity:
       // 0/1 properties cannot be toggled in the same tick
       // see: https://codepen.io/isnerms/pen/eyQaLP
@@ -62,29 +60,24 @@ export default class Toast extends Component {
     }
   }
 
-  // TODO: getting rid of the destroy state all together would simplify this
-  // (if props.show changes => do the show/hide stuff)
-  UNSAFE_componentWillReceiveProps(nextProps) {
-    const { destroy } = this.state;
-
-    if (destroy && nextProps.show) {
-      // update from hidden to show
-      this.setState({ animationClass: 'dqpl-fadein-setup' }, () => {
-        // Timeout because CSS display: none/block and opacity:
-        // 0/1 properties cannot be toggled in the same tick
-        // see: https://codepen.io/isnerms/pen/eyQaLP
-        setTimeout(this.showToast);
-      });
-    } else if (!destroy && !nextProps.show) {
-      this.dismissToast();
+  componentDidUpdate(prevProps) {
+    const { show } = this.props;
+    if (prevProps.show !== show) {
+      if (show) {
+        this.setState({ animationClass: 'dqpl-fadein-setup' }, () => {
+          setTimeout(this.showToast);
+        });
+      } else {
+        this.dismissToast();
+      }
     }
   }
 
   render() {
-    const { animationClass, destroy } = this.state;
-    const { type, children, dismissText, toastRef } = this.props;
+    const { animationClass } = this.state;
+    const { type, children, dismissText, toastRef, show } = this.props;
     const scrim =
-      type === 'action-needed' && !destroy ? (
+      type === 'action-needed' && show ? (
         <div className="dqpl-scrim-light dqpl-scrim-show dqpl-scrim-fade-in" />
       ) : null;
 
@@ -139,10 +132,7 @@ export default class Toast extends Component {
             isolator.deactivate();
           }
 
-          this.setState(
-            { destroy: true, animationClass: 'dqpl-hidden' },
-            onDismiss
-          );
+          this.setState({ animationClass: 'dqpl-hidden' }, onDismiss);
         });
       }
     );
@@ -153,7 +143,6 @@ export default class Toast extends Component {
 
     this.setState(
       {
-        destroy: false,
         animationClass: 'dqpl-fadein-setup dqpl-fadein'
       },
       () => {


### PR DESCRIPTION
`<Toast>` should now show/hide based on `show` prop alone. 

Ref: #28 