### PR TITLE
fix: demo unable to open sidebar when collapsed

### DIFF
--- a/demo/index.js
+++ b/demo/index.js
@@ -45,8 +45,10 @@ class App extends Component {
     this.onTriggerClick = this.onTriggerClick.bind(this);
   }
 
-  onTriggerClick() {
+  onTriggerClick(e) {
     const { show } = this.state;
+
+    e && e.preventDefault();
 
     if (show && this.topBarTrigger) {
       this.topBarTrigger.focus();

--- a/demo/index.js
+++ b/demo/index.js
@@ -48,7 +48,9 @@ class App extends Component {
   onTriggerClick(e) {
     const { show } = this.state;
 
-    e && e.preventDefault();
+    if (e) {
+      e.preventDefault();
+    }
 
     if (show && this.topBarTrigger) {
       this.topBarTrigger.focus();

--- a/src/components/MenuItem/index.js
+++ b/src/components/MenuItem/index.js
@@ -30,7 +30,7 @@ export default class MenuItem extends Component {
     if (autoClickLink) {
       clickLink(e.target, this.item);
     }
-    onClick();
+    onClick(e);
   }
 
   onKeyDown(e) {


### PR DESCRIPTION
When the sidebar was collapsed, `<ClickOutsideListener>` was triggering on the toggle button in the menu since the menu would first open then bubble up to the click outside immediately closing preventing the user from being able to open the sidebar.