### PR TITLE
fix: mark `classnames` as a production dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   "author": "Harris Schneiderman",
   "license": "MPL-2.0",
   "dependencies": {
+    "classnames": "^2.2.6",
     "focus-trap-react": "^3.0.5",
     "keyname": "^0.1.0",
     "prop-types": "^15.6.0",
@@ -56,7 +57,6 @@
     "babel-loader": "^8.0.5",
     "babel-plugin-module-resolver": "^3.0.0",
     "babel-plugin-transform-export-extensions": "^6.22.0",
-    "classnames": "^2.2.5",
     "closest": "0.0.1",
     "css-loader": "^0.28.7",
     "deque-pattern-library": "^6.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2416,8 +2416,8 @@ class-utils@^0.3.5:
 
 classnames@^2.2.6:
   version "2.2.6"
-  resolved "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/classnames/-/classnames-2.2.6.tgz#43935bffdd291f326dad0a205309b38d00f650ce"
-  integrity sha1-Q5Nb/90pHzJtrQogUwmzjQD2UM4=
+  resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.2.6.tgz#43935bffdd291f326dad0a205309b38d00f650ce"
+  integrity sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q==
 
 clean-css@4.2.x:
   version "4.2.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2414,10 +2414,10 @@ class-utils@^0.3.5:
     isobject "^3.0.0"
     static-extend "^0.1.1"
 
-classnames@^2.2.5, classnames@^2.2.6:
+classnames@^2.2.6:
   version "2.2.6"
-  resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.2.6.tgz#43935bffdd291f326dad0a205309b38d00f650ce"
-  integrity sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q==
+  resolved "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/classnames/-/classnames-2.2.6.tgz#43935bffdd291f326dad0a205309b38d00f650ce"
+  integrity sha1-Q5Nb/90pHzJtrQogUwmzjQD2UM4=
 
 clean-css@4.2.x:
   version "4.2.1"


### PR DESCRIPTION
This patch makes our `classnames` dependency a production dependency (rather than a development dependency). This is needed as [the package is used at runtime](https://github.com/dequelabs/cauldron-react/blob/v0.5.1/src/components/Button/index.js#L3).