### PR TITLE
fix: don't run animations when animationTiming is not set

### DIFF
--- a/__tests__/src/components/ExpandCollapsePanel/ExpandCollapsePanel.js
+++ b/__tests__/src/components/ExpandCollapsePanel/ExpandCollapsePanel.js
@@ -52,7 +52,7 @@ test('should have hidden content when collapsed', () => {
 
 test('should have visible content when expanded', () => {
   const wrapper = mount(
-    <ExpandCollapsePanel animationTiming={0}>
+    <ExpandCollapsePanel animationTiming={1}>
       <div data-test>foo</div>
     </ExpandCollapsePanel>
   );
@@ -95,7 +95,7 @@ test('should call onToggle when toggled', () => {
 
 test('trigger should open panel collapsed panel', () => {
   const wrapper = mount(
-    <ExpandCollapsePanel animationTiming={0}>
+    <ExpandCollapsePanel animationTiming={1}>
       <PanelTrigger />
       <div data-test />
     </ExpandCollapsePanel>
@@ -110,7 +110,7 @@ test('trigger should open panel collapsed panel', () => {
 
 test('trigger should close expanded panel', () => {
   const wrapper = mount(
-    <ExpandCollapsePanel animationTiming={0}>
+    <ExpandCollapsePanel animationTiming={1}>
       <PanelTrigger />
       <div data-test />
     </ExpandCollapsePanel>
@@ -127,7 +127,7 @@ test('trigger should close expanded panel', () => {
 test('should clean up injected styletags', () => {
   const cleanup = jest.spyOn(stylesheets, 'removeStyleTag');
   const wrapper = mount(
-    <ExpandCollapsePanel animationTiming={0}>
+    <ExpandCollapsePanel animationTiming={1}>
       <PanelTrigger />
       <div />
     </ExpandCollapsePanel>
@@ -135,4 +135,19 @@ test('should clean up injected styletags', () => {
   wrapper.setState({ isOpen: true });
   wrapper.unmount();
   expect(cleanup).toBeCalled();
+});
+
+test('should not run animations if timing is not set', () => {
+  const setStyle = jest.spyOn(stylesheets, 'setStyle');
+  const wrapper = mount(
+    <ExpandCollapsePanel animationTiming={0}>
+      <PanelTrigger />
+      <div />
+    </ExpandCollapsePanel>
+  );
+  wrapper.find('PanelTrigger').simulate('click', {});
+
+  setTimeout(() => {
+    expect(setStyle).not.toBeCalled();
+  });
 });

--- a/src/components/ExpandCollapsePanel/ExpandCollapsePanel.js
+++ b/src/components/ExpandCollapsePanel/ExpandCollapsePanel.js
@@ -12,7 +12,7 @@ export default class ExpandCollapsePanel extends React.Component {
   static propTypes = {
     children: PropTypes.node.isRequired,
     className: PropTypes.string,
-    animationTiming: PropTypes.number,
+    animationTiming: PropTypes.oneOfType([PropTypes.number, PropTypes.bool]),
     onToggle: PropTypes.func
   };
 
@@ -37,6 +37,10 @@ export default class ExpandCollapsePanel extends React.Component {
   animateOpen = () => {
     const { current: panel } = this.panel;
     const { animationTiming } = this.props;
+
+    if (!animationTiming) {
+      return;
+    }
 
     const rect = panel.getBoundingClientRect();
 
@@ -72,6 +76,10 @@ export default class ExpandCollapsePanel extends React.Component {
     const { current: panel } = this.panel;
     const { animationTiming } = this.props;
     const { styleTag } = this;
+
+    if (!animationTiming) {
+      return;
+    }
 
     const rect = panel.getBoundingClientRect();
     setStyle(

--- a/types.d.ts
+++ b/types.d.ts
@@ -313,7 +313,7 @@ export const ClickOutsideListener: React.ComponentType<
 interface ExpandCollapsePanelProps
   extends React.HTMLAttributes<HTMLDivElement> {
   children: React.ReactNode;
-  animationTiming?: number;
+  animationTiming?: number | boolean;
   onToggle?: (e: React.MouseEvent<HTMLButtonElement>) => void;
 }
 


### PR DESCRIPTION
I noticed that occasionally an element could flicker as an animation was being queued and then immediately removed if the timing was set to `0`. This fixes that by only queueing animation styles when an animation is set to run.