### PR TITLE
fix: actually run assertions in tests for expand/collapse component

### DIFF
--- a/src/components/ExpandCollapsePanel/ExpandCollapsePanel.js
+++ b/src/components/ExpandCollapsePanel/ExpandCollapsePanel.js
@@ -39,6 +39,7 @@ export default class ExpandCollapsePanel extends React.Component {
     const { animationTiming } = this.props;
 
     if (!animationTiming) {
+      this.setState({ isAnimating: false });
       return;
     }
 
@@ -78,6 +79,7 @@ export default class ExpandCollapsePanel extends React.Component {
     const { styleTag } = this;
 
     if (!animationTiming) {
+      this.setState({ isAnimating: false });
       return;
     }
 


### PR DESCRIPTION
My assertions weren't actually running, which led me to believe my original changes were working correctly. 🤦‍♂

* Use `dqpl-hidden` class as visibility check as deque-pattern-library's style aren't included in jest's dom
* Fix issue where a panel being re-closed with `0` animation time was not actually hidden.
* Clean-up tests and actually run assertions