### PR TITLE
fix: allow classnames to be added to existing menuitem class

### DIFF
--- a/__tests__/src/components/OptionsMenu/OptionsMenu.js
+++ b/__tests__/src/components/OptionsMenu/OptionsMenu.js
@@ -309,6 +309,17 @@ test('should click child links with keypress events', () => {
   expect(onClick).toBeCalledTimes(1);
 });
 
+test('should passthrough classname to menuitem', () => {
+  const optionsMenu = mount(
+    <OptionsMenu {...defaultProps}>
+      <li className="foo">option 1</li>
+    </OptionsMenu>
+  );
+  const menuItem = optionsMenu.find('li');
+  expect(menuItem.hasClass('foo')).toBeTruthy();
+  expect(menuItem.hasClass('dqpl-options-menuitem')).toBeTruthy();
+});
+
 test('should return no axe violations', async () => {
   const optionsMenu = mount(
     <OptionsMenu {...defaultProps}>

--- a/src/components/OptionsMenu/OptionsMenu.js
+++ b/src/components/OptionsMenu/OptionsMenu.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import ClickOutsideListener from '../ClickOutsideListener';
+import classnames from 'classnames';
 
 export default class OptionsMenu extends Component {
   static propTypes = {
@@ -54,16 +55,19 @@ export default class OptionsMenu extends Component {
       ...other
     } = this.props;
     /* eslint-enable no-unused-vars */
-    const items = children.map(({ props }, i) => (
-      <li
-        key={`list-item-${i}`}
-        className="dqpl-options-menuitem"
-        tabIndex={-1}
-        role="menuitem"
-        ref={el => (this.itemRefs[i] = el)}
-        {...props}
-      />
-    ));
+    const items = React.Children.map(children, ({ props }, i) => {
+      const { className, ...other } = props;
+      return (
+        <li
+          key={`list-item-${i}`}
+          className={classnames('dqpl-options-menuitem', className)}
+          tabIndex={-1}
+          role="menuitem"
+          ref={el => (this.itemRefs[i] = el)}
+          {...other}
+        />
+      );
+    });
 
     return (
       <ClickOutsideListener onClickOutside={this.handleClickOutside}>


### PR DESCRIPTION
MenuItem's class was getting clobbered, my guess is we probably don't want to overwrite the existing class but just append it.