### PR TITLE
fix: don't render falsy children in OptionsMenu

### DIFF
--- a/__tests__/src/components/OptionsMenu/OptionsMenu.js
+++ b/__tests__/src/components/OptionsMenu/OptionsMenu.js
@@ -55,6 +55,17 @@ test('handles updates to `itemIndex` state', () => {
   );
 });
 
+test('should not render falsy children', () => {
+  const wrapper = mount(
+    <OptionsMenu {...defaultProps} show={true}>
+      <li>option 1</li>
+      {false && <li>option 2</li>}
+      <li>option 3</li>
+    </OptionsMenu>
+  );
+  expect(wrapper.find('li')).toHaveLength(2);
+});
+
 test('handles up/down keydowns', () => {
   expect.assertions(3);
   const wrapper = mount(

--- a/src/components/OptionsMenu/OptionsMenu.js
+++ b/src/components/OptionsMenu/OptionsMenu.js
@@ -55,7 +55,7 @@ export default class OptionsMenu extends Component {
       ...other
     } = this.props;
     /* eslint-enable no-unused-vars */
-    const items = React.Children.map(children, ({ props }, i) => {
+    const items = React.Children.toArray(children).map(({ props }, i) => {
       const { className, ...other } = props;
       return (
         <li


### PR DESCRIPTION
Falsy children were being rendered in `<OptionsMenu>` causing there to be ghost menu items inside of the list allow for mouse/keyboard interactions.