### PR TITLE
feat: allow OptionsMenuItem to be disabled

### DIFF
--- a/__tests__/src/components/OptionsMenu/OptionsMenuItem.js
+++ b/__tests__/src/components/OptionsMenu/OptionsMenuItem.js
@@ -1,0 +1,47 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import {
+  default as OptionsMenu,
+  OptionsMenuItem
+} from 'src/components/OptionsMenu';
+import { axe } from 'jest-axe';
+
+const defaultMenuProps = {
+  show: false,
+  id: 'foo',
+  onClose: () => {}
+};
+
+test('should call onSelect when menuitem is clicked', () => {
+  const onSelect = jest.fn();
+  const optionsMenu = mount(
+    <OptionsMenu {...defaultMenuProps}>
+      <OptionsMenuItem onSelect={onSelect}>option 1</OptionsMenuItem>
+    </OptionsMenu>
+  );
+  optionsMenu.find('li').simulate('click', {});
+  expect(onSelect).toBeCalled();
+});
+
+test('should not call onSelect when menuitem is disabled', () => {
+  const onSelect = jest.fn();
+  const optionsMenu = mount(
+    <OptionsMenu {...defaultMenuProps}>
+      <OptionsMenuItem onSelect={onSelect} disabled>
+        option 1
+      </OptionsMenuItem>
+    </OptionsMenu>
+  );
+  optionsMenu.find('li').simulate('click');
+  expect(onSelect).not.toBeCalled();
+});
+
+test('should return no axe violations', async () => {
+  const optionsMenu = mount(
+    <OptionsMenu {...defaultMenuProps}>
+      <OptionsMenuItem>option 1</OptionsMenuItem>
+      <OptionsMenuItem>option 2</OptionsMenuItem>
+    </OptionsMenu>
+  );
+  expect(await axe(optionsMenu.html())).toHaveNoViolations();
+});

--- a/__tests__/typechecks.tsx
+++ b/__tests__/typechecks.tsx
@@ -138,7 +138,9 @@ const options = () => (
       hi
     </OptionsMenuTrigger>
     <OptionsMenu onClose={noop} onSelect={noop} id="id" show closeOnSelect>
-      <OptionsMenuItem>hi</OptionsMenuItem>
+      <OptionsMenuItem onSelect={noop} disabled className="hi">
+        hi
+      </OptionsMenuItem>
     </OptionsMenu>
   </OptionsMenuWrapper>
 );

--- a/src/components/OptionsMenu/OptionsMenu.js
+++ b/src/components/OptionsMenu/OptionsMenu.js
@@ -55,18 +55,16 @@ export default class OptionsMenu extends Component {
       ...other
     } = this.props;
     /* eslint-enable no-unused-vars */
-    const items = React.Children.toArray(children).map(({ props }, i) => {
-      const { className, ...other } = props;
-      return (
-        <li
-          key={`list-item-${i}`}
-          className={classnames('dqpl-options-menuitem', className)}
-          tabIndex={-1}
-          role="menuitem"
-          ref={el => (this.itemRefs[i] = el)}
-          {...other}
-        />
-      );
+    const items = React.Children.toArray(children).map((child, i) => {
+      const { className, ...other } = child.props;
+      return React.cloneElement(child, {
+        key: `list-item-${i}`,
+        className: classnames('dqpl-options-menuitem', className),
+        tabIndex: -1,
+        role: 'menuitem',
+        ref: el => (this.itemRefs[i] = el),
+        ...other
+      });
     });
 
     return (

--- a/src/components/OptionsMenu/OptionsMenuItem.js
+++ b/src/components/OptionsMenu/OptionsMenuItem.js
@@ -1,32 +1,37 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-const OptionsMenuItem = React.forwardRef(
-  ({ disabled, onSelect, ...other }, ref) => {
-    const handleClick = event => {
-      if (!disabled) {
-        onSelect(event);
-      }
-    };
+class OptionsMenuItemComponent extends React.Component {
+  static propTypes = {
+    disabled: PropTypes.bool,
+    className: PropTypes.string,
+    onSelect: PropTypes.func
+  };
 
+  handleClick = event => {
+    const { disabled, onSelect } = this.props;
+    if (!disabled) {
+      onSelect(event);
+    }
+  };
+
+  render() {
+    const { handleClick, props } = this;
+    const { menuItemRef, disabled, ...other } = props;
     return (
       // keydown happens in OptionsMenu which proxies to click
       // eslint-disable-next-line jsx-a11y/click-events-have-key-events
       <li
         role="menuitem"
-        ref={ref}
+        ref={menuItemRef}
         aria-disabled={disabled}
         onClick={handleClick}
         {...other}
       />
     );
   }
-);
+}
 
-OptionsMenuItem.propTypes = {
-  disabled: PropTypes.bool,
-  className: PropTypes.string,
-  onSelect: PropTypes.func
-};
-
-export default OptionsMenuItem;
+export default React.forwardRef(function OptionsMenuItem(props, ref) {
+  return <OptionsMenuItemComponent menuItemRef={ref} {...props} />;
+});

--- a/src/components/OptionsMenu/OptionsMenuItem.js
+++ b/src/components/OptionsMenu/OptionsMenuItem.js
@@ -1,12 +1,32 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 
-/**
- * The options menu item component which should be used
- * as direct children of the <OptionsMenu /> component.
- *
- * NOTE: This is a dummy component in which props are
- * actually set within the <OptionsMenu /> component
- * (See src/lib/components/OptionsMenu/index.js for details)
- */
-const OptionsMenuItem = props => <div {...props} />;
+const OptionsMenuItem = React.forwardRef(
+  ({ disabled, onSelect, ...other }, ref) => {
+    const handleClick = event => {
+      if (!disabled) {
+        onSelect(event);
+      }
+    };
+
+    return (
+      // keydown happens in OptionsMenu which proxies to click
+      // eslint-disable-next-line jsx-a11y/click-events-have-key-events
+      <li
+        role="menuitem"
+        ref={ref}
+        aria-disabled={disabled}
+        onClick={handleClick}
+        {...other}
+      />
+    );
+  }
+);
+
+OptionsMenuItem.propTypes = {
+  disabled: PropTypes.bool,
+  className: PropTypes.string,
+  onSelect: PropTypes.func
+};
+
 export default OptionsMenuItem;

--- a/types.d.ts
+++ b/types.d.ts
@@ -189,7 +189,15 @@ interface OptionsMenuProps {
 
 export const OptionsMenu: React.ComponentType<OptionsMenuProps>;
 
-interface OptionsMenuItemProps extends React.HTMLAttributes<HTMLDivElement> {}
+interface OptionsMenuItemProps
+  extends Pick<
+      React.HTMLAttributes<HTMLLIElement>,
+      Exclude<keyof React.HTMLAttributes<HTMLLIElement>, 'onSelect'>
+    > {
+  disabled?: boolean;
+  className?: string;
+  onSelect?: (e: React.MouseEvent<HTMLElement>) => void;
+}
 
 export const OptionsMenuItem: React.ComponentType<OptionsMenuItemProps>;
 


### PR DESCRIPTION
Attest currently allows MenuItems to be disabled.

![options menu with disabled items](https://user-images.githubusercontent.com/1062039/58886441-832efb00-86a9-11e9-8663-d75046927f43.png)

This functionality was formally handled inside of dropdown of _dqpl-react_, but since we're moving things over to cauldron just replicating the functionality here. In addition, adding an `onSelect` property to match the `onSelect` callback of `<OptionsMenu>`. When disabled, this event should not fire.