### PR TITLE
feat: split OptionsMenu into List and controlled component

### DIFF
--- a/__tests__/src/components/OptionsMenu/OptionsMenu.js
+++ b/__tests__/src/components/OptionsMenu/OptionsMenu.js
@@ -3,337 +3,74 @@ import { mount } from 'enzyme';
 import OptionsMenu from 'src/components/OptionsMenu';
 import { axe } from 'jest-axe';
 
-const defaultProps = {
-  show: false,
-  id: 'foo',
-  onClose: () => {}
-};
+const trigger = props => (
+  <button data-trigger type="button" {...props}>
+    foo
+  </button>
+);
 
-const [space, enter, down, esc, tab] = [32, 13, 40, 27, 9];
+const [down] = [40];
 
-test('handles a newly truthy `show` prop', () => {
-  expect.assertions(1);
+test('should render children', () => {
   const wrapper = mount(
-    <OptionsMenu {...defaultProps}>
+    <OptionsMenu trigger={trigger}>
       <li>option 1</li>
       <li>option 2</li>
-    </OptionsMenu>
-  );
-
-  wrapper.setProps({
-    show: true
-  });
-
-  expect(document.activeElement).toBe(
-    wrapper
-      .find('li')
-      .at(0)
-      .getDOMNode()
-  );
-});
-
-test('handles updates to `itemIndex` state', () => {
-  expect.assertions(1);
-  const wrapper = mount(
-    <OptionsMenu {...defaultProps} show={true}>
-      <li>option 1</li>
-      <li>option 2</li>
-    </OptionsMenu>
-  );
-  // focus the first item
-  wrapper
-    .find('li')
-    .at(0)
-    .getDOMNode()
-    .focus();
-  wrapper.setState({ itemIndex: 1 });
-  expect(document.activeElement).toBe(
-    wrapper
-      .find('li')
-      .at(1)
-      .getDOMNode()
-  );
-});
-
-test('should not render falsy children', () => {
-  const wrapper = mount(
-    <OptionsMenu {...defaultProps} show={true}>
-      <li>option 1</li>
-      {false && <li>option 2</li>}
-      <li>option 3</li>
     </OptionsMenu>
   );
   expect(wrapper.find('li')).toHaveLength(2);
 });
 
-test('handles up/down keydowns', () => {
-  expect.assertions(3);
-  const wrapper = mount(
-    <OptionsMenu {...defaultProps} show={true}>
-      <li>option 1</li>
-      <li>option 2</li>
-    </OptionsMenu>
-  );
-  expect(wrapper.state('itemIndex')).toBe(0);
-
-  wrapper
-    .find('li')
-    .at(0)
-    .simulate('keydown', { which: down });
-  expect(wrapper.state('itemIndex')).toBe(1);
-
-  wrapper
-    .find('li')
-    .at(0)
-    .simulate('keydown', { which: down });
-  expect(wrapper.state('itemIndex')).toBe(0); // circular
-});
-
-test('calls onClose given escape keydown', () => {
-  let onClose = jest.fn();
-  const wrapper = mount(
-    <OptionsMenu {...defaultProps} show={true} onClose={onClose}>
-      <li>option 1</li>
-      <li>option 2</li>
-    </OptionsMenu>
-  );
-  wrapper
-    .find('li')
-    .at(0)
-    .simulate('keydown', { which: esc });
-
-  expect(onClose).toBeCalled();
-});
-
-test('calls onClose given a tab keydown', () => {
-  let onClose = jest.fn();
-  const wrapper = mount(
-    <OptionsMenu {...defaultProps} show={true} onClose={onClose}>
-      <li>option 1</li>
-      <li>option 2</li>
-    </OptionsMenu>
-  );
-  wrapper
-    .find('li')
-    .at(0)
-    .simulate('keydown', { which: tab });
-
-  expect(onClose).toBeCalled();
-});
-
-test('calls onClose when clicked outside', () => {
-  let onClose = jest.fn();
-  const wrapper = mount(
-    <OptionsMenu {...defaultProps} show={true} onClose={onClose}>
-      <li>option 1</li>
-      <li>option 2</li>
-    </OptionsMenu>
-  );
-  wrapper.instance().handleClickOutside();
-
-  expect(onClose).toBeCalled();
-});
-
-test('handles enter / space keydowns', () => {
-  expect.assertions(1);
-  let clickHandler = jest.fn();
-  const wrapper = mount(
-    <OptionsMenu {...defaultProps} show={true}>
-      <li>option 1</li>
-      <li>option 2</li>
-    </OptionsMenu>
-  );
-  const element = wrapper
-    .find('li')
-    .at(0)
-    .getDOMNode();
-  element.addEventListener('click', clickHandler);
-  wrapper
-    .find('li')
-    .at(0)
-    .simulate('keydown', { which: enter });
-
-  expect(clickHandler).toBeCalled();
-});
-
-test('fires onSelect when menu item is clicked', () => {
-  const onSelect = jest.fn();
-  const wrapper = mount(
-    <OptionsMenu {...defaultProps} onSelect={onSelect}>
-      <li>option 1</li>
-      <li>option 2</li>
-    </OptionsMenu>
-  );
-  let item = wrapper.find('li').at(0);
-  let itemNode = item.getDOMNode();
-  item.simulate('click', { target: itemNode });
-
-  expect(onSelect).toBeCalled();
-  expect(onSelect).toHaveBeenCalledWith(
-    expect.objectContaining({ target: itemNode })
-  );
-});
-
-test('fires onSelect when menu item is selected with space', () => {
-  const onSelect = jest.fn();
-  const wrapper = mount(
-    <OptionsMenu {...defaultProps} onSelect={onSelect}>
-      <li>option 1</li>
-      <li>option 2</li>
-    </OptionsMenu>
-  );
-
-  let item = wrapper.find('li').at(0);
-  let itemNode = item.getDOMNode();
-
-  // Synthetic events that call delegated events apparently don't bubble correctly in enzyme
-  itemNode.addEventListener('click', event => {
-    item.simulate('click', event);
-  });
-
-  item.simulate('keydown', { which: space, target: item.getDOMNode() });
-
-  expect(onSelect).toBeCalled();
-  expect(onSelect).toHaveBeenCalledWith(
-    expect.objectContaining({ target: itemNode })
-  );
-});
-
-test('fires onSelect when menu item is selected with enter', () => {
-  const onSelect = jest.fn();
-  const wrapper = mount(
-    <OptionsMenu {...defaultProps} onSelect={onSelect}>
-      <li>option 1</li>
-      <li>option 2</li>
-    </OptionsMenu>
-  );
-
-  let item = wrapper.find('li').at(0);
-  let itemNode = item.getDOMNode();
-
-  // Synthetic events that call delegated events apparently don't bubble correctly in enzyme
-  itemNode.addEventListener('click', event => {
-    item.simulate('click', event);
-  });
-
-  item.simulate('keydown', { which: enter, target: item.getDOMNode() });
-
-  expect(onSelect).toBeCalled();
-  expect(onSelect).toHaveBeenCalledWith(
-    expect.objectContaining({ target: itemNode })
-  );
-});
-
-test('fires onClose when menu item is selected', () => {
-  const onClose = jest.fn();
-  const wrapper = mount(
-    <OptionsMenu {...defaultProps} onClose={onClose}>
-      <li>option 1</li>
-      <li>option 2</li>
-    </OptionsMenu>
-  );
-
-  wrapper
-    .find('li')
-    .at(0)
-    .simulate('click');
-
-  expect(onClose).toBeCalled();
-});
-
-test('does not fire onClose when menu item is selected and default prevented', () => {
-  const onClose = jest.fn();
-  const wrapper = mount(
-    <OptionsMenu {...defaultProps} onClose={onClose}>
-      <li>option 1</li>
-      <li>option 2</li>
-    </OptionsMenu>
-  );
-
-  wrapper
-    .find('li')
-    .at(0)
-    .simulate('click', { defaultPrevented: true });
-
-  expect(onClose).not.toBeCalled();
-});
-
-test('does not fire onClose when menu item is selected and closeOnSelect is false', () => {
-  const onClose = jest.fn();
-  const wrapper = mount(
-    <OptionsMenu {...defaultProps} onClose={onClose} closeOnSelect={false}>
-      <li>option 1</li>
-      <li>option 2</li>
-    </OptionsMenu>
-  );
-
-  wrapper
-    .find('li')
-    .at(0)
-    .simulate('click');
-
-  expect(onClose).not.toBeCalled();
-});
-
-test('should click child links when clicking on list item', () => {
-  const onClick = jest.fn();
-  const wrapper = mount(
-    <OptionsMenu {...defaultProps}>
-      <li>
-        <a href="#foo">Click me!</a>
-      </li>
-      <li>option 2</li>
-    </OptionsMenu>
-  );
-
-  const item = wrapper.find('li').at(0);
-  wrapper
-    .find('a')
-    .getDOMNode()
-    .addEventListener('click', onClick);
-  item.simulate('click');
-
-  expect(onClick).toBeCalledTimes(1);
-});
-
-test('should click child links with keypress events', () => {
-  const onClick = jest.fn();
-  const wrapper = mount(
-    <OptionsMenu {...defaultProps}>
-      <li>
-        <a href="#foo">Click me!</a>
-      </li>
-      <li>option 2</li>
-    </OptionsMenu>
-  );
-
-  const item = wrapper.find('li').at(0);
-  wrapper
-    .find('a')
-    .getDOMNode()
-    .addEventListener('click', onClick);
-  item
-    .getDOMNode()
-    .addEventListener('click', event => item.simulate('click', event));
-  item.simulate('keydown', { which: enter });
-
-  expect(onClick).toBeCalledTimes(1);
-});
-
-test('should passthrough classname to menuitem', () => {
+test('should render trigger prop', () => {
   const optionsMenu = mount(
-    <OptionsMenu {...defaultProps}>
+    <OptionsMenu trigger={trigger}>
       <li className="foo">option 1</li>
     </OptionsMenu>
   );
-  const menuItem = optionsMenu.find('li');
-  expect(menuItem.hasClass('foo')).toBeTruthy();
-  expect(menuItem.hasClass('dqpl-options-menuitem')).toBeTruthy();
+  expect(optionsMenu.find('[data-trigger]')).toHaveLength(1);
+});
+
+test('should toggle menu on trigger clicks', () => {
+  const optionsMenu = mount(
+    <OptionsMenu trigger={trigger}>
+      <li className="foo">option 1</li>
+    </OptionsMenu>
+  );
+
+  const button = optionsMenu.find('[data-trigger]');
+  button.simulate('click');
+  expect(optionsMenu.state('show')).toBeTruthy();
+  button.simulate('click');
+  expect(optionsMenu.state('show')).toBeFalsy();
+});
+
+test('should click trigger with down key on trigger', () => {
+  const optionsMenu = mount(
+    <OptionsMenu trigger={trigger}>
+      <li className="foo">option 1</li>
+    </OptionsMenu>
+  );
+  const button = optionsMenu.find('[data-trigger]');
+  const onClick = jest.spyOn(button.getDOMNode(), 'click');
+  button.simulate('keydown', { which: down, target: button.getDOMNode() });
+  expect(onClick).toBeCalled();
+});
+
+test('should focus trigger on close', () => {
+  const optionsMenu = mount(
+    <OptionsMenu trigger={trigger}>
+      <li className="foo">option 1</li>
+    </OptionsMenu>
+  );
+  const button = optionsMenu.find('[data-trigger]');
+  const focus = jest.spyOn(button.getDOMNode(), 'focus');
+  optionsMenu.instance().handleClose();
+  expect(focus).toBeCalled();
 });
 
 test('should return no axe violations', async () => {
   const optionsMenu = mount(
-    <OptionsMenu {...defaultProps}>
+    <OptionsMenu trigger={trigger}>
       <li>option 1</li>
       <li>option 2</li>
     </OptionsMenu>

--- a/__tests__/src/components/OptionsMenu/OptionsMenu.js
+++ b/__tests__/src/components/OptionsMenu/OptionsMenu.js
@@ -68,6 +68,18 @@ test('should focus trigger on close', () => {
   expect(focus).toBeCalled();
 });
 
+test('should call onClose when closed', () => {
+  const onClose = jest.fn();
+  const optionsMenu = mount(
+    <OptionsMenu trigger={trigger} onClose={onClose}>
+      <li className="foo">option 1</li>
+    </OptionsMenu>
+  );
+  optionsMenu.setState({ show: true });
+  optionsMenu.find('.foo').simulate('click');
+  expect(onClose).toBeCalled();
+});
+
 test('should return no axe violations', async () => {
   const optionsMenu = mount(
     <OptionsMenu trigger={trigger}>

--- a/__tests__/src/components/OptionsMenu/OptionsMenuItem.js
+++ b/__tests__/src/components/OptionsMenu/OptionsMenuItem.js
@@ -7,9 +7,12 @@ import {
 import { axe } from 'jest-axe';
 
 const defaultMenuProps = {
-  show: false,
-  id: 'foo',
-  onClose: () => {}
+  // eslint-disable-next-line react/display-name
+  trigger: props => (
+    <button {...props} type="button">
+      thingy
+    </button>
+  )
 };
 
 test('should call onSelect when menuitem is clicked', () => {

--- a/__tests__/src/components/OptionsMenu/OptionsMenuList.js
+++ b/__tests__/src/components/OptionsMenu/OptionsMenuList.js
@@ -1,0 +1,330 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import { OptionsMenuList } from 'src/components/OptionsMenu';
+import { axe } from 'jest-axe';
+
+const [space, enter, down, esc, tab] = [32, 13, 40, 27, 9];
+const noop = () => {};
+
+const defaultProps = {
+  onClose: noop
+};
+
+test('should render children', () => {
+  const wrapper = mount(
+    <OptionsMenuList {...defaultProps} show={true}>
+      <li>option 1</li>
+      <li>option 2</li>
+    </OptionsMenuList>
+  );
+  expect(wrapper.find('li')).toHaveLength(2);
+});
+
+test('should not render falsy children', () => {
+  const wrapper = mount(
+    <OptionsMenuList {...defaultProps} show={true}>
+      <li>option 1</li>
+      {false && <li>option 2</li>}
+      <li>option 3</li>
+    </OptionsMenuList>
+  );
+  expect(wrapper.find('li')).toHaveLength(2);
+});
+
+test('handles up/down keydowns', () => {
+  expect.assertions(3);
+  const wrapper = mount(
+    <OptionsMenuList {...defaultProps} show={true}>
+      <li>option 1</li>
+      <li>option 2</li>
+    </OptionsMenuList>
+  );
+  expect(wrapper.state('itemIndex')).toBe(0);
+
+  wrapper
+    .find('li')
+    .at(0)
+    .simulate('keydown', { which: down });
+  expect(wrapper.state('itemIndex')).toBe(1);
+
+  wrapper
+    .find('li')
+    .at(0)
+    .simulate('keydown', { which: down });
+  expect(wrapper.state('itemIndex')).toBe(0); // circular
+});
+
+test('calls onClose given escape keydown', () => {
+  let onClose = jest.fn();
+  const wrapper = mount(
+    <OptionsMenuList show={true} onClose={onClose}>
+      <li>option 1</li>
+      <li>option 2</li>
+    </OptionsMenuList>
+  );
+  wrapper
+    .find('li')
+    .at(0)
+    .simulate('keydown', { which: esc });
+
+  expect(onClose).toBeCalled();
+});
+
+test('calls onClose given a tab keydown', () => {
+  let onClose = jest.fn();
+  const wrapper = mount(
+    <OptionsMenuList show={true} onClose={onClose}>
+      <li>option 1</li>
+      <li>option 2</li>
+    </OptionsMenuList>
+  );
+  wrapper
+    .find('li')
+    .at(0)
+    .simulate('keydown', { which: tab });
+
+  expect(onClose).toBeCalled();
+});
+
+test('calls onClose when clicked outside', () => {
+  let onClose = jest.fn();
+  const wrapper = mount(
+    <OptionsMenuList show={true} onClose={onClose}>
+      <li>option 1</li>
+      <li>option 2</li>
+    </OptionsMenuList>
+  );
+  wrapper.instance().handleClickOutside();
+
+  expect(onClose).toBeCalled();
+});
+
+test('handles enter / space keydowns', () => {
+  expect.assertions(1);
+  let clickHandler = jest.fn();
+  const wrapper = mount(
+    <OptionsMenuList {...defaultProps} show={true}>
+      <li>option 1</li>
+      <li>option 2</li>
+    </OptionsMenuList>
+  );
+  const element = wrapper
+    .find('li')
+    .at(0)
+    .getDOMNode();
+  element.addEventListener('click', clickHandler);
+  wrapper
+    .find('li')
+    .at(0)
+    .simulate('keydown', { which: enter });
+
+  expect(clickHandler).toBeCalled();
+});
+
+test('fires onSelect when menu item is clicked', () => {
+  const onSelect = jest.fn();
+  const wrapper = mount(
+    <OptionsMenuList {...defaultProps} onSelect={onSelect}>
+      <li>option 1</li>
+      <li>option 2</li>
+    </OptionsMenuList>
+  );
+  let item = wrapper.find('li').at(0);
+  let itemNode = item.getDOMNode();
+  item.simulate('click', { target: itemNode });
+
+  expect(onSelect).toBeCalled();
+  expect(onSelect).toHaveBeenCalledWith(
+    expect.objectContaining({ target: itemNode })
+  );
+});
+
+test('fires onSelect when menu item is selected with space', () => {
+  const onSelect = jest.fn();
+  const wrapper = mount(
+    <OptionsMenuList {...defaultProps} onSelect={onSelect}>
+      <li>option 1</li>
+      <li>option 2</li>
+    </OptionsMenuList>
+  );
+
+  let item = wrapper.find('li').at(0);
+  let itemNode = item.getDOMNode();
+
+  // Synthetic events that call delegated events apparently don't bubble correctly in enzyme
+  itemNode.addEventListener('click', event => {
+    item.simulate('click', event);
+  });
+
+  item.simulate('keydown', { which: space, target: item.getDOMNode() });
+
+  expect(onSelect).toBeCalled();
+  expect(onSelect).toHaveBeenCalledWith(
+    expect.objectContaining({ target: itemNode })
+  );
+});
+
+test('fires onSelect when menu item is selected with enter', () => {
+  const onSelect = jest.fn();
+  const wrapper = mount(
+    <OptionsMenuList {...defaultProps} onSelect={onSelect}>
+      <li>option 1</li>
+      <li>option 2</li>
+    </OptionsMenuList>
+  );
+
+  let item = wrapper.find('li').at(0);
+  let itemNode = item.getDOMNode();
+
+  // Synthetic events that call delegated events apparently don't bubble correctly in enzyme
+  itemNode.addEventListener('click', event => {
+    item.simulate('click', event);
+  });
+
+  item.simulate('keydown', { which: enter, target: item.getDOMNode() });
+
+  expect(onSelect).toBeCalled();
+  expect(onSelect).toHaveBeenCalledWith(
+    expect.objectContaining({ target: itemNode })
+  );
+});
+
+test('fires onClose when menu item is selected', () => {
+  const onClose = jest.fn();
+  const wrapper = mount(
+    <OptionsMenuList onClose={onClose}>
+      <li>option 1</li>
+      <li>option 2</li>
+    </OptionsMenuList>
+  );
+
+  wrapper
+    .find('li')
+    .at(0)
+    .simulate('click');
+
+  expect(onClose).toBeCalled();
+});
+
+test('does not fire onClose when menu item is selected and default prevented', () => {
+  const onClose = jest.fn();
+  const wrapper = mount(
+    <OptionsMenuList onClose={onClose}>
+      <li>option 1</li>
+      <li>option 2</li>
+    </OptionsMenuList>
+  );
+
+  wrapper
+    .find('li')
+    .at(0)
+    .simulate('click', { defaultPrevented: true });
+
+  expect(onClose).not.toBeCalled();
+});
+
+test('does not fire onClose when menu item is selected and closeOnSelect is false', () => {
+  const onClose = jest.fn();
+  const wrapper = mount(
+    <OptionsMenuList onClose={onClose} closeOnSelect={false}>
+      <li>option 1</li>
+      <li>option 2</li>
+    </OptionsMenuList>
+  );
+
+  wrapper
+    .find('li')
+    .at(0)
+    .simulate('click');
+
+  expect(onClose).not.toBeCalled();
+});
+
+test('should click child links when clicking on list item', () => {
+  const onClick = jest.fn();
+  const wrapper = mount(
+    <OptionsMenuList {...defaultProps}>
+      <li>
+        <a href="#foo">Click me!</a>
+      </li>
+      <li>option 2</li>
+    </OptionsMenuList>
+  );
+
+  const item = wrapper.find('li').at(0);
+  wrapper
+    .find('a')
+    .getDOMNode()
+    .addEventListener('click', onClick);
+  item.simulate('click');
+
+  expect(onClick).toBeCalledTimes(1);
+});
+
+test('should click child links with keypress events', () => {
+  const onClick = jest.fn();
+  const wrapper = mount(
+    <OptionsMenuList {...defaultProps}>
+      <li>
+        <a href="#foo">Click me!</a>
+      </li>
+      <li>option 2</li>
+    </OptionsMenuList>
+  );
+
+  const item = wrapper.find('li').at(0);
+  wrapper
+    .find('a')
+    .getDOMNode()
+    .addEventListener('click', onClick);
+  item
+    .getDOMNode()
+    .addEventListener('click', event => item.simulate('click', event));
+  item.simulate('keydown', { which: enter });
+
+  expect(onClick).toBeCalledTimes(1);
+});
+
+test('should passthrough classname to menuitem', () => {
+  const optionsMenu = mount(
+    <OptionsMenuList {...defaultProps}>
+      <li className="foo">option 1</li>
+    </OptionsMenuList>
+  );
+  const menuItem = optionsMenu.find('li');
+  expect(menuItem.hasClass('foo')).toBeTruthy();
+  expect(menuItem.hasClass('dqpl-options-menuitem')).toBeTruthy();
+});
+
+test('handles updates to `itemIndex` state', () => {
+  expect.assertions(1);
+  const wrapper = mount(
+    <OptionsMenuList {...defaultProps} show={true}>
+      <li>option 1</li>
+      <li>option 2</li>
+    </OptionsMenuList>
+  );
+  // focus the first item
+  wrapper
+    .find('li')
+    .at(0)
+    .getDOMNode()
+    .focus();
+  wrapper.setState({ itemIndex: 1 });
+  expect(document.activeElement).toBe(
+    wrapper
+      .find('li')
+      .at(1)
+      .getDOMNode()
+  );
+});
+
+test('should return no axe violations', async () => {
+  const optionsMenu = mount(
+    <OptionsMenuList {...defaultProps}>
+      <li>option 1</li>
+      <li>option 2</li>
+    </OptionsMenuList>
+  );
+  expect(await axe(optionsMenu.html())).toHaveNoViolations();
+});

--- a/__tests__/src/components/OptionsMenu/OptionsMenuTrigger.js
+++ b/__tests__/src/components/OptionsMenu/OptionsMenuTrigger.js
@@ -3,27 +3,10 @@ import { mount } from 'enzyme';
 import Trigger from 'src/components/OptionsMenu/OptionsMenuTrigger';
 import { axe } from 'jest-axe';
 
-test('handles clicks', () => {
-  expect.assertions(3);
-  let called = false;
-  const trigger = mount(<Trigger onClick={() => (called = true)} />);
-  expect(trigger.state('expanded')).toBe(false);
-  trigger.simulate('click');
-  expect(called).toBeTruthy();
-  expect(trigger.state('expanded')).toBe(true);
-});
-
-test('handles keydowns', () => {
-  expect.assertions(2);
-  let called = false,
-    clicked = false;
-  const trigger = mount(<Trigger onKeyDown={() => (called = true)} />);
-  const domElement = trigger.getDOMNode();
-  domElement.addEventListener('click', () => (clicked = true));
-  trigger.simulate('keydown', { which: 40 });
-
-  expect(called).toBeTruthy();
-  expect(clicked).toBeTruthy();
+test('should render children', () => {
+  const child = 'hi';
+  const trigger = mount(<Trigger>{child}</Trigger>);
+  expect(trigger.find(child)).toBeTruthy();
 });
 
 test('should return no axe violations', async () => {

--- a/__tests__/src/components/TopBar/TopBarMenu.js
+++ b/__tests__/src/components/TopBar/TopBarMenu.js
@@ -3,7 +3,7 @@ import { mount } from 'enzyme';
 import MenuItem from 'src/components/MenuItem';
 import TopBar from 'src/components/TopBar/TopBar';
 import TopBarMenu from 'src/components/TopBar/TopBarMenu';
-import OptionsMenu from 'src/components/OptionsMenu';
+import { OptionsMenuList } from 'src/components/OptionsMenu';
 import { axe } from 'jest-axe';
 
 const [right, left, down] = [39, 37, 40];
@@ -14,17 +14,17 @@ const defaultProps = {
 };
 
 const optionsMenu = (
-  <OptionsMenu onClose={noop}>
+  <OptionsMenuList onClose={noop}>
     <li>option 1</li>
     <li>option 2</li>
-  </OptionsMenu>
+  </OptionsMenuList>
 );
 
 test('should render children', () => {
   const topBarMenu = mount(
     <TopBarMenu {...defaultProps}>{optionsMenu}</TopBarMenu>
   );
-  expect(topBarMenu.find('OptionsMenu').length).toBeTruthy();
+  expect(topBarMenu.find('OptionsMenuList').length).toBeTruthy();
 });
 
 test('should pass-through props', () => {

--- a/__tests__/typechecks.tsx
+++ b/__tests__/typechecks.tsx
@@ -127,22 +127,28 @@ const modal = () => (
 
 const offscreen = () => <Offscreen className="bananas">offscreen</Offscreen>;
 
+const optionsWrapper = () => {
+  <OptionsMenuWrapper align="left">
+    <div />
+  </OptionsMenuWrapper>;
+};
+
+const optionsTrigger = () => {
+  <OptionsMenuTrigger>hi</OptionsMenuTrigger>;
+};
+
 const options = () => (
-  <OptionsMenuWrapper>
-    <OptionsMenuTrigger
-      className="hi"
-      onClick={noopEventHandler}
-      onKeyDown={noopEventHandler}
-      triggerRef={noopRef}
-    >
+  <OptionsMenu
+    trigger={() => optionsTrigger}
+    align="left"
+    onClose={noop}
+    onSelect={noop}
+    closeOnSelect
+  >
+    <OptionsMenuItem onSelect={noop} disabled className="hi">
       hi
-    </OptionsMenuTrigger>
-    <OptionsMenu onClose={noop} onSelect={noop} id="id" show closeOnSelect>
-      <OptionsMenuItem onSelect={noop} disabled className="hi">
-        hi
-      </OptionsMenuItem>
-    </OptionsMenu>
-  </OptionsMenuWrapper>
+    </OptionsMenuItem>
+  </OptionsMenu>
 );
 
 const radio = () => (

--- a/demo/index.js
+++ b/demo/index.js
@@ -30,7 +30,7 @@ import {
   SideBar,
   SkipLink,
   MenuItem,
-  OptionsMenu,
+  OptionsMenuList,
   TopBarMenu
 } from 'src/';
 
@@ -124,10 +124,10 @@ class App extends Component {
             {showTopBarMenu && (
               <TopBarMenu id="topbar-menu" className="dqpl-right-aligned">
                 {`I'm a menu thingy`}
-                <OptionsMenu>
+                <OptionsMenuList>
                   <li>Item 1</li>
                   <li>Item 2</li>
-                </OptionsMenu>
+                </OptionsMenuList>
               </TopBarMenu>
             )}
 

--- a/demo/patterns/components/OptionsMenu/index.js
+++ b/demo/patterns/components/OptionsMenu/index.js
@@ -1,48 +1,43 @@
 import React, { Component } from 'react';
 import Highlight from '../../../Highlight';
-import {
-  OptionsMenu,
-  OptionsMenuItem,
-  OptionsMenuWrapper,
-  OptionsMenuTrigger,
-  Icon
-} from 'src/';
+import { OptionsMenu, OptionsMenuItem, OptionsMenuTrigger, Icon } from 'src/';
 
 export default class Demo extends Component {
-  constructor() {
-    super();
-
-    this.state = { show: false };
-    this.toggleMenu = this.toggleMenu.bind(this);
-    this.onClose = this.onClose.bind(this);
-  }
-
   render() {
-    const { show } = this.state;
-
     return (
       <div>
         <h1>Options Menu</h1>
         <h2>Demo</h2>
-        <OptionsMenuWrapper className="dqpl-align-left">
-          <OptionsMenuTrigger
-            onClick={this.toggleMenu}
-            triggerRef={el => (this.trigger = el)}
-            aria-controls="options-menu-demo"
-          >
-            <Icon type="fa-ellipsis-v" label="Options" />
-          </OptionsMenuTrigger>
-          <OptionsMenu
-            id="options-menu-demo"
-            onClose={this.onClose}
-            show={show}
-          >
-            <OptionsMenuItem>This</OptionsMenuItem>
-            <OptionsMenuItem>That</OptionsMenuItem>
-            <OptionsMenuItem>The third</OptionsMenuItem>
-            <OptionsMenuItem disabled>And the other</OptionsMenuItem>
-          </OptionsMenu>
-        </OptionsMenuWrapper>
+        <h3>Options Menu (Default Trigger)</h3>
+        <OptionsMenu
+          align="left"
+          trigger={triggerProps => (
+            <OptionsMenuTrigger {...triggerProps}>
+              <Icon type="fa-ellipsis-v" label="Options" />
+            </OptionsMenuTrigger>
+          )}
+        >
+          <OptionsMenuItem>This</OptionsMenuItem>
+          <OptionsMenuItem>That</OptionsMenuItem>
+          <OptionsMenuItem>The third</OptionsMenuItem>
+          <OptionsMenuItem disabled>And the other</OptionsMenuItem>
+        </OptionsMenu>
+
+        <h3>Options Menu (Custom Trigger)</h3>
+        <OptionsMenu
+          align="left"
+          trigger={triggerProps => (
+            <button type="button" {...triggerProps}>
+              Menu
+            </button>
+          )}
+        >
+          <OptionsMenuItem>This</OptionsMenuItem>
+          <OptionsMenuItem>That</OptionsMenuItem>
+          <OptionsMenuItem>The third</OptionsMenuItem>
+          <OptionsMenuItem disabled>And the other</OptionsMenuItem>
+        </OptionsMenu>
+
         <h2>Code Sample</h2>
         <Highlight language="javascript">
           {`
@@ -50,59 +45,46 @@ import React, { Component } from 'react';
 import {
   OptionsMenu,
   OptionsMenuItem,
-  OptionsMenuWrapper,
   OptionsMenuTrigger,
   Icon
 } from 'cauldron-react';
 
 class Demo extends Component {
-  constructor() {
-    super();
-
-    this.state = { show: false };
-    this.toggleMenu = this.toggleMenu.bind(this);
-    this.onClose = this.onClose.bind(this);
-  }
 
   render() {
     const { show } = this.state;
 
     return (
       <div>
-        <h1>Options Menu</h1>
-        <h2>Demo</h2>
-        <OptionsMenuWrapper className='dqpl-align-left'>
-          <OptionsMenuTrigger
-            onClick={this.toggleMenu}
-            triggerRef={el => this.trigger = el}
-            aria-controls='options-menu-demo'
-          >
-            <Icon type='fa-ellipsis-v' label='Options' />
-          </OptionsMenuTrigger>
-          <OptionsMenu
-            id='options-menu-demo'
-            onClose={this.onClose}
-            show={show}
-          >
-            <OptionsMenuItem>This</OptionsMenuItem>
-            <OptionsMenuItem>That</OptionsMenuItem>
-            <OptionsMenuItem>The third</OptionsMenuItem>
-            <OptionsMenuItem disabled>And the other</OptionsMenuItem>
-          </OptionsMenu>
-        </OptionsMenuWrapper>
+        <h3>Options Menu (Default Trigger)</h3>
+        <OptionsMenu
+          align="left"
+          trigger={triggerProps => (
+            <OptionsMenuTrigger {...triggerProps}>
+              <Icon type="fa-ellipsis-v" label="Options" />
+            </OptionsMenuTrigger>
+          )}
+        >
+          <OptionsMenuItem>This</OptionsMenuItem>
+          <OptionsMenuItem>That</OptionsMenuItem>
+          <OptionsMenuItem>The third</OptionsMenuItem>
+          <OptionsMenuItem disabled>And the other</OptionsMenuItem>
+        </OptionsMenu>
+
+        <h3>Options Menu (Custom Trigger)</h3>
+        <OptionsMenu
+          align="left"
+          trigger={triggerProps => (
+            <button type="button" {...triggerProps}>Menu</button>
+          )}
+        >
+          <OptionsMenuItem>This</OptionsMenuItem>
+          <OptionsMenuItem>That</OptionsMenuItem>
+          <OptionsMenuItem>The third</OptionsMenuItem>
+          <OptionsMenuItem disabled>And the other</OptionsMenuItem>
+        </OptionsMenu>
       </div>
     );
-  }
-
-  toggleMenu() {
-    this.setState(({ show }) => ({
-      show: !show
-    }));
-  }
-
-  onClose() {
-    this.toggleMenu();
-    this.trigger.focus();
   }
 }
 
@@ -110,17 +92,5 @@ class Demo extends Component {
         </Highlight>
       </div>
     );
-  }
-
-  toggleMenu(e) {
-    e && e.preventDefault();
-    this.setState(({ show }) => ({
-      show: !show
-    }));
-  }
-
-  onClose() {
-    this.toggleMenu();
-    this.trigger.focus();
   }
 }

--- a/src/components/OptionsMenu/OptionsMenu.js
+++ b/src/components/OptionsMenu/OptionsMenu.js
@@ -1,158 +1,91 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import ClickOutsideListener from '../ClickOutsideListener';
-import classnames from 'classnames';
+import OptionsMenuWrapper from './OptionsMenuWrapper';
+import OptionsMenuList from './OptionsMenuList';
+
+const [down] = [40];
 
 export default class OptionsMenu extends Component {
   static propTypes = {
+    trigger: PropTypes.func.isRequired,
     children: PropTypes.node.isRequired,
-    onClose: PropTypes.func.isRequired,
+    onClose: PropTypes.func,
     className: PropTypes.string,
     onSelect: PropTypes.func,
-    show: PropTypes.bool,
     closeOnSelect: PropTypes.bool,
-    menuRef: PropTypes.func
+    menuRef: PropTypes.func,
+    align: PropTypes.oneOf(['left', 'right'])
   };
 
   static defaultProps = {
-    show: false,
-    closeOnSelect: true,
-    className: 'dqpl-options-menu',
-    onSelect: () => {}
+    onClose: () => {},
+    onSelect: () => {},
+    align: 'right'
   };
 
   constructor() {
     super();
-    this.itemRefs = [];
-    this.state = { itemIndex: 0 };
-    this.handleKeyDown = this.handleKeyDown.bind(this);
-    this.handleClick = this.handleClick.bind(this);
-    this.handleClickOutside = this.handleClickOutside.bind(this);
+    this.state = { show: false };
+    this.triggerRef = React.createRef();
     this.menuRef = React.createRef();
   }
 
-  componentDidUpdate(prevProps, prevState) {
-    const { itemIndex } = this.state;
-    const { show } = this.props;
+  toggleMenu = event => {
+    this.setState(({ show }) => ({ show: !show }));
+    event.preventDefault();
+  };
 
-    if (!prevProps.show && show && this.itemRefs.length) {
-      // handles opens
-      this.itemRefs[0].focus();
-    } else if (prevState.itemIndex !== itemIndex) {
-      // handle up/down arrows
-      this.itemRefs[itemIndex].focus();
+  handleClose = () => {
+    this.setState({ show: false });
+    this.props.onClose();
+    this.triggerRef.current.focus();
+  };
+
+  handleTriggerKeyDown = event => {
+    const { which, target } = event;
+    if (which === down) {
+      event.preventDefault();
+      target.click();
     }
-  }
+  };
 
   render() {
+    const { toggleMenu, triggerRef, handleTriggerKeyDown } = this;
     /* eslint-disable no-unused-vars */
     const {
       children,
       className,
-      show,
       closeOnSelect,
       menuRef,
+      trigger,
+      align,
       ...other
     } = this.props;
+
     /* eslint-enable no-unused-vars */
-    const items = React.Children.toArray(children).map((child, i) => {
-      const { className, ...other } = child.props;
-      return React.cloneElement(child, {
-        key: `list-item-${i}`,
-        className: classnames('dqpl-options-menuitem', className),
-        tabIndex: -1,
-        role: 'menuitem',
-        ref: el => (this.itemRefs[i] = el),
-        ...other
-      });
-    });
+    const { show } = this.state;
 
     return (
-      <ClickOutsideListener onClickOutside={this.handleClickOutside}>
-        <ul
-          {...other}
-          className={className}
-          aria-expanded={show}
-          role="menu"
-          onClick={this.handleClick}
-          onKeyDown={this.handleKeyDown}
+      <OptionsMenuWrapper align={align}>
+        {trigger({
+          onClick: toggleMenu,
+          'aria-expanded': show,
+          ref: triggerRef,
+          onKeyDown: handleTriggerKeyDown
+        })}
+        <OptionsMenuList
+          show={show}
           ref={el => {
             this.menuRef = el;
             if (menuRef) {
               menuRef(el);
             }
           }}
+          onClose={this.handleClose}
         >
-          {items}
-        </ul>
-      </ClickOutsideListener>
+          {children}
+        </OptionsMenuList>
+      </OptionsMenuWrapper>
     );
-  }
-
-  handleClick(e) {
-    const { menuRef, props } = this;
-    const { onSelect, onClose } = props;
-    if (menuRef && menuRef.contains(e.target)) {
-      if (!e.defaultPrevented && props.closeOnSelect) {
-        onClose();
-      }
-
-      onSelect(e);
-    }
-
-    const link = e.target.querySelector('a');
-    if (link) {
-      link.click();
-    }
-  }
-
-  handleClickOutside() {
-    const { show, onClose } = this.props;
-    if (show) {
-      onClose();
-    }
-  }
-
-  handleKeyDown(e) {
-    const { which, target } = e;
-    switch (which) {
-      // up / down
-      case 38:
-      case 40: {
-        const { itemIndex } = this.state;
-        const itemCount = this.itemRefs.length;
-        let newIndex = which === 38 ? itemIndex - 1 : itemIndex + 1;
-
-        // circularity
-        if (newIndex === -1) {
-          newIndex = itemCount - 1;
-        } else if (newIndex === itemCount) {
-          newIndex = 0;
-        }
-
-        e.preventDefault();
-        this.setState({
-          itemIndex: newIndex
-        });
-
-        break;
-      }
-      // escape
-      case 27:
-        this.props.onClose();
-
-        break;
-      // enter / space
-      case 13:
-      case 32:
-        e.preventDefault();
-        target.click();
-
-        break;
-      // tab
-      case 9:
-        e.preventDefault();
-        this.props.onClose();
-    }
   }
 }

--- a/src/components/OptionsMenu/OptionsMenu.js
+++ b/src/components/OptionsMenu/OptionsMenu.js
@@ -82,6 +82,7 @@ export default class OptionsMenu extends Component {
             }
           }}
           onClose={this.handleClose}
+          {...other}
         >
           {children}
         </OptionsMenuList>

--- a/src/components/OptionsMenu/OptionsMenu.js
+++ b/src/components/OptionsMenu/OptionsMenu.js
@@ -59,6 +59,7 @@ export default class OptionsMenu extends Component {
       menuRef,
       trigger,
       align,
+      onClose,
       ...other
     } = this.props;
 

--- a/src/components/OptionsMenu/OptionsMenuList.js
+++ b/src/components/OptionsMenu/OptionsMenuList.js
@@ -136,7 +136,7 @@ export default class OptionsMenuList extends React.Component {
       <ClickOutsideListener onClickOutside={this.handleClickOutside}>
         <ul
           {...other}
-          className={('dqpl-options-menu', className)}
+          className={classnames('dqpl-options-menu', className)}
           /* aria-expanded is not correct usage here, but the pattern library
              currently styles the open state of the menu. based on this attribute */
           aria-expanded={show}

--- a/src/components/OptionsMenu/OptionsMenuList.js
+++ b/src/components/OptionsMenu/OptionsMenuList.js
@@ -18,7 +18,6 @@ export default class OptionsMenuList extends React.Component {
 
   static defaultProps = {
     closeOnSelect: true,
-    className: 'dqpl-options-menu',
     onSelect: () => {}
   };
 
@@ -137,7 +136,7 @@ export default class OptionsMenuList extends React.Component {
       <ClickOutsideListener onClickOutside={this.handleClickOutside}>
         <ul
           {...other}
-          className={className}
+          className={('dqpl-options-menu', className)}
           /* aria-expanded is not correct usage here, but the pattern library
              currently styles the open state of the menu. based on this attribute */
           aria-expanded={show}

--- a/src/components/OptionsMenu/OptionsMenuList.js
+++ b/src/components/OptionsMenu/OptionsMenuList.js
@@ -1,0 +1,159 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import ClickOutsideListener from '../ClickOutsideListener';
+import classnames from 'classnames';
+
+const [up, down, tab, enter, space, esc] = [38, 40, 9, 13, 32, 27];
+
+export default class OptionsMenuList extends React.Component {
+  static propTypes = {
+    show: PropTypes.bool,
+    children: PropTypes.node.isRequired,
+    onClose: PropTypes.func.isRequired,
+    className: PropTypes.string,
+    onSelect: PropTypes.func,
+    closeOnSelect: PropTypes.bool,
+    menuRef: PropTypes.func
+  };
+
+  static defaultProps = {
+    closeOnSelect: true,
+    className: 'dqpl-options-menu',
+    onSelect: () => {}
+  };
+
+  constructor() {
+    super();
+    this.itemRefs = [];
+    this.state = { itemIndex: 0 };
+  }
+
+  componentDidUpdate(prevProps, prevState) {
+    const { itemIndex } = this.state;
+    const { show } = this.props;
+
+    if (!prevProps.show && show && this.itemRefs.length) {
+      // handles opens
+      this.itemRefs[0].focus();
+      this.setState({ itemIndex: 0 });
+    } else if (prevState.itemIndex !== itemIndex) {
+      // handle up/down arrows
+      this.itemRefs[itemIndex].focus();
+    }
+  }
+
+  handleKeyDown = e => {
+    const { onClose } = this.props;
+    const { which, target } = e;
+    switch (which) {
+      case up:
+      case down: {
+        const { itemIndex } = this.state;
+        const itemCount = this.itemRefs.length;
+        let newIndex = which === 38 ? itemIndex - 1 : itemIndex + 1;
+
+        // circularity
+        if (newIndex === -1) {
+          newIndex = itemCount - 1;
+        } else if (newIndex === itemCount) {
+          newIndex = 0;
+        }
+
+        e.preventDefault();
+        this.setState({
+          itemIndex: newIndex
+        });
+
+        break;
+      }
+      case esc:
+        onClose();
+
+        break;
+      case enter:
+      case space:
+        e.preventDefault();
+        target.click();
+
+        break;
+      case tab:
+        e.preventDefault();
+        onClose();
+    }
+  };
+
+  handleClick = e => {
+    const { menuRef, props } = this;
+    const { onSelect, onClose } = props;
+    if (menuRef && menuRef.contains(e.target)) {
+      if (!e.defaultPrevented && props.closeOnSelect) {
+        onClose();
+      }
+
+      onSelect(e);
+    }
+
+    const link = e.target.querySelector('a');
+    if (link) {
+      link.click();
+    }
+  };
+
+  handleClickOutside = () => {
+    const { onClose, show } = this.props;
+    if (show) {
+      onClose();
+    }
+  };
+
+  render() {
+    const { props, handleClick, handleKeyDown } = this;
+    /* eslint-disable no-unused-vars */
+    const {
+      children,
+      menuRef,
+      show,
+      className,
+      onClose,
+      onSelect,
+      closeOnSelect,
+      ...other
+    } = props;
+    /* eslint-enable no-unused-vars */
+
+    const items = React.Children.toArray(children).map((child, i) => {
+      const { className, ...other } = child.props;
+      return React.cloneElement(child, {
+        key: `list-item-${i}`,
+        className: classnames('dqpl-options-menuitem', className),
+        tabIndex: -1,
+        role: 'menuitem',
+        ref: el => (this.itemRefs[i] = el),
+        ...other
+      });
+    });
+
+    return (
+      <ClickOutsideListener onClickOutside={this.handleClickOutside}>
+        <ul
+          {...other}
+          className={className}
+          /* aria-expanded is not correct usage here, but the pattern library
+             currently styles the open state of the menu. based on this attribute */
+          aria-expanded={show}
+          role="menu"
+          onKeyDown={handleKeyDown}
+          onClick={handleClick}
+          ref={el => {
+            this.menuRef = el;
+            if (menuRef) {
+              menuRef(el);
+            }
+          }}
+        >
+          {items}
+        </ul>
+      </ClickOutsideListener>
+    );
+  }
+}

--- a/src/components/OptionsMenu/OptionsMenuTrigger.js
+++ b/src/components/OptionsMenu/OptionsMenuTrigger.js
@@ -1,68 +1,36 @@
-import React, { Component } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import keyname from 'keyname';
 
 /**
- * The trigger button component to be used as the component
+ * The trigger button component to be used as the default component
  * that triggers the opening of an <OptionsMenu />.
- *
- * NOTE: This component should be used to set/update the <OptionsMenu /> "show" property
  */
-export default class OptionsMenuTrigger extends Component {
-  static propTypes = {
-    onKeyDown: PropTypes.func,
-    onClick: PropTypes.func,
-    triggerRef: PropTypes.func,
-    className: PropTypes.string
-  };
-
-  static defaultProps = {
-    onKeyDown: () => {},
-    onClick: () => {},
-    triggerRef: () => {}
-  };
-
-  constructor() {
-    super();
-    this.state = { expanded: false };
-    this.onKeyDown = this.onKeyDown.bind(this);
-    this.onClick = this.onClick.bind(this);
-  }
-
-  render() {
-    const { expanded } = this.state;
-    const { triggerRef, className, ...other } = this.props;
-
-    return (
-      <button
-        type="button"
-        {...other}
-        aria-expanded={expanded}
-        className={classNames('dqpl-options-menu-trigger', className)}
-        ref={triggerRef}
-        onKeyDown={this.onKeyDown}
-        onClick={this.onClick}
-      />
-    );
-  }
-
-  onClick(e) {
-    this.props.onClick(e);
-
-    this.setState({
-      expanded: !this.state.expanded
-    });
-  }
-
-  onKeyDown(e) {
-    this.props.onKeyDown(e);
-    const { which, target } = e;
-    const key = keyname(which);
-
-    if (key === 'down') {
-      e.preventDefault();
-      target.click();
-    }
-  }
+function OptionsMenuTriggerComponent({ className, triggerRef, ...other }) {
+  return (
+    <button
+      type="button"
+      ref={triggerRef}
+      {...other}
+      className={classNames('dqpl-options-menu-trigger', className)}
+    />
+  );
 }
+
+OptionsMenuTriggerComponent.propTypes = {
+  children: PropTypes.node.isRequired,
+  className: PropTypes.string,
+  ref: PropTypes.oneOfType([
+    PropTypes.func,
+    PropTypes.shape({ current: PropTypes.instanceOf(Element) })
+  ]),
+  // I don't think this correct, but it shouldn't be accessible anyway
+  triggerRef: PropTypes.oneOfType([
+    PropTypes.func,
+    PropTypes.shape({ current: PropTypes.instanceOf(Element) })
+  ])
+};
+
+export default React.forwardRef(function OptionsMenuTrigger(props, ref) {
+  return <OptionsMenuTriggerComponent {...props} triggerRef={ref} />;
+});

--- a/src/components/OptionsMenu/OptionsMenuTrigger.js
+++ b/src/components/OptionsMenu/OptionsMenuTrigger.js
@@ -20,11 +20,6 @@ function OptionsMenuTriggerComponent({ className, triggerRef, ...other }) {
 OptionsMenuTriggerComponent.propTypes = {
   children: PropTypes.node.isRequired,
   className: PropTypes.string,
-  ref: PropTypes.oneOfType([
-    PropTypes.func,
-    PropTypes.shape({ current: PropTypes.instanceOf(Element) })
-  ]),
-  // I don't think this correct, but it shouldn't be accessible anyway
   triggerRef: PropTypes.oneOfType([
     PropTypes.func,
     PropTypes.shape({ current: PropTypes.instanceOf(Element) })

--- a/src/components/OptionsMenu/OptionsMenuWrapper.js
+++ b/src/components/OptionsMenu/OptionsMenuWrapper.js
@@ -2,13 +2,33 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
+const menuAlignment = type => {
+  switch (type) {
+    case 'left':
+      return 'dqpl-align-left';
+    case 'right':
+      return 'dqpl-align-right';
+  }
+};
+
 /**
  * Wrapper / parent component for the <OptionsMenuTrigger /> and <OptionsMenu /> components
  */
-const OptionsMenuWrapper = ({ className, ...other }) => (
-  <div className={classNames('dqpl-options-menu-wrap', className)} {...other} />
+const OptionsMenuWrapper = ({ className, align, ...other }) => (
+  <div
+    className={classNames(
+      'dqpl-options-menu-wrap',
+      menuAlignment(align),
+      className
+    )}
+    {...other}
+  />
 );
 
-OptionsMenuWrapper.propTypes = { className: PropTypes.string };
+OptionsMenuWrapper.propTypes = {
+  children: PropTypes.node.isRequired,
+  className: PropTypes.string,
+  align: PropTypes.oneOf(['left', 'right'])
+};
 
 export default OptionsMenuWrapper;

--- a/src/components/OptionsMenu/index.css
+++ b/src/components/OptionsMenu/index.css
@@ -1,0 +1,5 @@
+/* override top from options-menu */
+/* this should be moved to dqpl-pattern-library */
+.dqpl-options-menu-wrap .dqpl-options-menu {
+  top: 100%;
+}

--- a/src/components/OptionsMenu/index.js
+++ b/src/components/OptionsMenu/index.js
@@ -1,4 +1,5 @@
 export { default } from './OptionsMenu';
+export { default as OptionsMenuList } from './OptionsMenuList';
 export { default as OptionsMenuItem } from './OptionsMenuItem';
 export { default as OptionsMenuTrigger } from './OptionsMenuTrigger';
 export { default as OptionsMenuWrapper } from './OptionsMenuWrapper';

--- a/src/components/TopBar/TopBarMenu.js
+++ b/src/components/TopBar/TopBarMenu.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import MenuItem from '../MenuItem';
-import OptionsMenu from '../OptionsMenu';
+import { OptionsMenuList } from '../OptionsMenu';
 import classnames from 'classnames';
 import keyname from 'keyname';
 
@@ -55,11 +55,11 @@ export default class TopBarMenu extends React.Component {
     const { children, id, ...other } = props;
     const { open } = state;
 
-    const optionsMenu = React.Children.toArray(children).find(
-      child => child.type === OptionsMenu
+    const menu = React.Children.toArray(children).find(
+      child => child.type === OptionsMenuList
     );
     const otherChildren = React.Children.toArray(children).filter(
-      child => typeof child === 'string' || child.type !== OptionsMenu
+      child => typeof child === 'string' || child.type !== OptionsMenuList
     );
 
     return (
@@ -77,7 +77,7 @@ export default class TopBarMenu extends React.Component {
         onKeyDown={handleKeyDown}
       >
         {otherChildren}
-        {React.cloneElement(optionsMenu, {
+        {React.cloneElement(menu, {
           id,
           className: classnames('dqpl-dropdown', {
             'dqpl-dropdown-active': open

--- a/src/index.css
+++ b/src/index.css
@@ -4,3 +4,4 @@
 @import './components/RadioGroup/index.css';
 @import './components/Tooltip/index.css';
 @import './components/ExpandCollapsePanel/index.css';
+@import './components/OptionsMenu/index.css';

--- a/src/index.js
+++ b/src/index.js
@@ -25,9 +25,9 @@ export Link from './components/Link';
 export Loader from './components/Loader';
 export {
   default as OptionsMenu,
+  OptionsMenuList,
   OptionsMenuItem,
-  OptionsMenuTrigger,
-  OptionsMenuWrapper
+  OptionsMenuTrigger
 } from './components/OptionsMenu';
 export Select from './components/Select';
 export RadioGroup from './components/RadioGroup';

--- a/types.d.ts
+++ b/types.d.ts
@@ -178,10 +178,20 @@ interface LoaderProps extends React.HTMLAttributes<HTMLDivElement> {
 
 export const Loader: React.ComponentType<LoaderProps>;
 
-interface OptionsMenuProps {
+interface OptionsMenuRenderTriggerProps {
+  onClick: (event: React.MouseEvent<HTMLElement>) => void;
+  show: boolean;
+  ref: RefCallback;
+  onKeyDown: (e: React.KeyboardEvent<HTMLElement>) => void;
+}
+
+interface OptionsMenuProps extends OptionsMenuAlignmentProps {
   children: React.ReactNode;
-  id: string;
-  onClose: () => void;
+  id?: string;
+  className?: string;
+  menuRef?: RefCallback;
+  trigger: (props: OptionsMenuRenderTriggerProps) => React.ReactNode;
+  onClose?: () => void;
   onSelect?: (e: React.MouseEvent<HTMLElement>) => void;
   closeOnSelect?: boolean;
   show?: boolean;
@@ -202,16 +212,21 @@ interface OptionsMenuItemProps
 export const OptionsMenuItem: React.ComponentType<OptionsMenuItemProps>;
 
 interface OptionsMenuTriggerProps {
-  onKeyDown?: (e: React.KeyboardEvent<HTMLButtonElement>) => void;
-  onClick?: (e: React.MouseEvent<HTMLButtonElement>) => void;
-  triggerRef?: RefCallback;
+  ref?: RefCallback;
   className?: string;
 }
 
 export const OptionsMenuTrigger: React.ComponentType<OptionsMenuTriggerProps>;
 
-interface OptionsMenuWrapperProps extends React.HTMLAttributes<HTMLDivElement> {
+interface OptionsMenuAlignmentProps {
+  align?: 'left' | 'right';
+}
+
+interface OptionsMenuWrapperProps
+  extends React.HTMLAttributes<HTMLDivElement>,
+    OptionsMenuAlignmentProps {
   className?: string;
+  children: React.ReactNode;
 }
 
 export const OptionsMenuWrapper: React.ComponentType<OptionsMenuWrapperProps>;


### PR DESCRIPTION
Split the existing `OptionsMenu` into:

* *Uncontrolled* Component: `<OptionsMenu>` 
* `<OptionsMenuList>` for managing list state.

Prior to this change, the `<OptionsMenu>` component was controlled meaning that any consumers were required to manage state. By converting the component to an uncontrolled component, consumers are no longer required to manage state.

**Example**

```
<OptionsMenu
  align="left"
  trigger={triggerProps => (
    <OptionsMenuTrigger {...triggerProps}>
      <Icon type="fa-ellipsis-v" label="Options" />
    </OptionsMenuTrigger>
  )}
>
  <OptionsMenuItem>This</OptionsMenuItem>
  <OptionsMenuItem>That</OptionsMenuItem>
  <OptionsMenuItem>The third</OptionsMenuItem>
  <OptionsMenuItem disabled>And the other</OptionsMenuItem>
</OptionsMenu>
```

**_Other Changes_**

* Fixed: Button/Menu states (`aria-expanded`) could become out of sync.
* Fixed: MenuListItem focus state could become out of sync if a user navigated through a list then re-opened.
* Added: The trigger is now a render prop allowing for complete customization of the trigger while allowing OptionsMenu to still wire up event handling/states correctly.
* Wrapping in `<OptionsMenuWrapper>` is no longer necessary since it's included as part of the `<OptionsMenu>` component. Instead an `align` prop is provided to allow for menu alignment.