### PR TITLE
chore: set react peer version to 16.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "url": "git+https://github.com/dequelabs/cauldron-react.git"
   },
   "peerDependencies": {
-    "react": "^16"
+    "react": "^16.6.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.4.3",


### PR DESCRIPTION
We're using `React.memo()` so bumping the peer version.