### PR TITLE
chore(release): 2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ All notable changes to this project will be documented in this file. See [standa
 - add topbar menu component ([#130](https://github.com/dequelabs/cauldron-react/issues/130)) ([24790d1](https://github.com/dequelabs/cauldron-react/commit/24790d1))
 - **Loader:** supports loader without label ([#135](https://github.com/dequelabs/cauldron-react/issues/135)) ([4352e1f](https://github.com/dequelabs/cauldron-react/commit/4352e1f)), closes [#133](https://github.com/dequelabs/cauldron-react/issues/133)
 - allow OptionsMenuItem to be disabled ([#139](https://github.com/dequelabs/cauldron-react/issues/139)) ([f4f6dfb](https://github.com/dequelabs/cauldron-react/commit/f4f6dfb))
+
+### Breaking Changes
+
 - split OptionsMenu into List and controlled component ([#141](https://github.com/dequelabs/cauldron-react/issues/141)) ([ce240be](https://github.com/dequelabs/cauldron-react/commit/ce240be))
 
 <a name="1.0.0"></a>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,9 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
-<a name="1.1.0"></a>
+<a name="2.0.0"></a>
 
-# [1.1.0](https://github.com/dequelabs/cauldron-react/compare/v1.0.0...v1.1.0) (2019-06-17)
+# [2.0.0](https://github.com/dequelabs/cauldron-react/compare/v1.0.0...v2.0.0) (2019-06-18)
 
 ### Bug Fixes
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cauldron-react",
-  "version": "1.1.0",
+  "version": "2.0.0",
   "description": "Fully accessible react components library for Deque Cauldron",
   "main": "lib/index.js",
   "style": "lib/cauldron.css",


### PR DESCRIPTION
`1.1.0` had a breaking change; re-releasing as `2.0.0`