### PR TITLE
fix: use native keyDown event for optionsmenu instead of React's synthetic event system

### DIFF
--- a/__tests__/src/components/OptionsMenu/OptionsMenuList.js
+++ b/__tests__/src/components/OptionsMenu/OptionsMenuList.js
@@ -41,16 +41,19 @@ test('handles up/down keydowns', () => {
   );
   expect(wrapper.state('itemIndex')).toBe(0);
 
-  wrapper
+  const li = wrapper
     .find('li')
     .at(0)
-    .simulate('keydown', { which: down });
+    .getDOMNode();
+
+  li.dispatchEvent(
+    new KeyboardEvent('keydown', { which: down, bubbles: true })
+  );
   expect(wrapper.state('itemIndex')).toBe(1);
 
-  wrapper
-    .find('li')
-    .at(0)
-    .simulate('keydown', { which: down });
+  li.dispatchEvent(
+    new KeyboardEvent('keydown', { which: down, bubbles: true })
+  );
   expect(wrapper.state('itemIndex')).toBe(0); // circular
 });
 
@@ -65,7 +68,8 @@ test('calls onClose given escape keydown', () => {
   wrapper
     .find('li')
     .at(0)
-    .simulate('keydown', { which: esc });
+    .getDOMNode()
+    .dispatchEvent(new KeyboardEvent('keydown', { which: esc, bubbles: true }));
 
   expect(onClose).toBeCalled();
 });
@@ -81,7 +85,8 @@ test('calls onClose given a tab keydown', () => {
   wrapper
     .find('li')
     .at(0)
-    .simulate('keydown', { which: tab });
+    .getDOMNode()
+    .dispatchEvent(new KeyboardEvent('keydown', { which: tab, bubbles: true }));
 
   expect(onClose).toBeCalled();
 });
@@ -116,7 +121,10 @@ test('handles enter / space keydowns', () => {
   wrapper
     .find('li')
     .at(0)
-    .simulate('keydown', { which: enter });
+    .getDOMNode()
+    .dispatchEvent(
+      new KeyboardEvent('keydown', { which: enter, bubbles: true })
+    );
 
   expect(clickHandler).toBeCalled();
 });
@@ -156,7 +164,11 @@ test('fires onSelect when menu item is selected with space', () => {
     item.simulate('click', event);
   });
 
-  item.simulate('keydown', { which: space, target: item.getDOMNode() });
+  item
+    .getDOMNode()
+    .dispatchEvent(
+      new KeyboardEvent('keydown', { which: space, bubbles: true })
+    );
 
   expect(onSelect).toBeCalled();
   expect(onSelect).toHaveBeenCalledWith(
@@ -181,7 +193,11 @@ test('fires onSelect when menu item is selected with enter', () => {
     item.simulate('click', event);
   });
 
-  item.simulate('keydown', { which: enter, target: item.getDOMNode() });
+  item
+    .getDOMNode()
+    .dispatchEvent(
+      new KeyboardEvent('keydown', { which: enter, bubbles: true })
+    );
 
   expect(onSelect).toBeCalled();
   expect(onSelect).toHaveBeenCalledWith(
@@ -280,7 +296,11 @@ test('should click child links with keypress events', () => {
   item
     .getDOMNode()
     .addEventListener('click', event => item.simulate('click', event));
-  item.simulate('keydown', { which: enter });
+  item
+    .getDOMNode()
+    .dispatchEvent(
+      new KeyboardEvent('keydown', { which: enter, bubbles: true })
+    );
 
   expect(onClick).toBeCalledTimes(1);
 });

--- a/src/components/OptionsMenu/OptionsMenuList.js
+++ b/src/components/OptionsMenu/OptionsMenuList.js
@@ -105,8 +105,17 @@ export default class OptionsMenuList extends React.Component {
     }
   };
 
+  componentDidMount() {
+    // see https://github.com/dequelabs/cauldron-react/issues/150
+    this.menuRef.addEventListener('keydown', this.handleKeyDown);
+  }
+
+  componentWillUnmount() {
+    this.menuRef.removeEventListener('keydown', this.handleKeyDown);
+  }
+
   render() {
-    const { props, handleClick, handleKeyDown } = this;
+    const { props, handleClick } = this;
     /* eslint-disable no-unused-vars */
     const {
       children,
@@ -132,6 +141,8 @@ export default class OptionsMenuList extends React.Component {
       });
     });
 
+    // Key event is being handled in componentDidMount
+    /* eslint-disable jsx-a11y/click-events-have-key-events */
     return (
       <ClickOutsideListener onClickOutside={this.handleClickOutside}>
         <ul
@@ -141,7 +152,6 @@ export default class OptionsMenuList extends React.Component {
              currently styles the open state of the menu. based on this attribute */
           aria-expanded={show}
           role="menu"
-          onKeyDown={handleKeyDown}
           onClick={handleClick}
           ref={el => {
             this.menuRef = el;
@@ -154,5 +164,6 @@ export default class OptionsMenuList extends React.Component {
         </ul>
       </ClickOutsideListener>
     );
+    /* eslint-enable jsx-a11y/click-events-have-key-events */
   }
 }


### PR DESCRIPTION
React's synthetic event handling was preventing us from stopping the devtools console panel from toggling (dequelabs/attest-browser-extensions#310) when closing a menu with <kbd>esc</kbd>. To bypass this and allow us to manually prevent this in the extension we're instead attaching `keydown` natively to the element.

Closes: #150 