### PR TITLE
feat: allow expand/collapse component to be controlled

### DIFF
--- a/__tests__/src/components/ExpandCollapsePanel/ExpandCollapsePanel.js
+++ b/__tests__/src/components/ExpandCollapsePanel/ExpandCollapsePanel.js
@@ -199,3 +199,15 @@ test('should allow for controlled component', () => {
   expect(wrapper.state()).toEqual({ controlled: true, isOpen: true });
   expect(isVisible(wrapper.find('[data-test]'))).toBeTruthy();
 });
+
+test.only('should be able to switch between controlled and uncontrolled component', () => {
+  const wrapper = mount(
+    <ExpandCollapsePanel animationTiming={0}>
+      <PanelTrigger />
+      <div data-test />
+    </ExpandCollapsePanel>
+  );
+  expect(wrapper.state('controlled')).toBeFalsy();
+  wrapper.setProps({ open: true });
+  expect(wrapper.state('controlled')).toBeTruthy();
+});

--- a/__tests__/src/components/ExpandCollapsePanel/ExpandCollapsePanel.js
+++ b/__tests__/src/components/ExpandCollapsePanel/ExpandCollapsePanel.js
@@ -188,3 +188,14 @@ test('should not run close animations if timing is not set', done => {
     done();
   });
 });
+
+test('should allow for controlled component', () => {
+  const wrapper = mount(
+    <ExpandCollapsePanel animationTiming={0} open={true}>
+      <PanelTrigger />
+      <div data-test />
+    </ExpandCollapsePanel>
+  );
+  expect(wrapper.state()).toEqual({ controlled: true, isOpen: true });
+  expect(isVisible(wrapper.find('[data-test]'))).toBeTruthy();
+});

--- a/__tests__/src/components/ExpandCollapsePanel/ExpandCollapsePanel.js
+++ b/__tests__/src/components/ExpandCollapsePanel/ExpandCollapsePanel.js
@@ -200,7 +200,7 @@ test('should allow for controlled component', () => {
   expect(isVisible(wrapper.find('[data-test]'))).toBeTruthy();
 });
 
-test.only('should be able to switch between controlled and uncontrolled component', () => {
+test('should be able to switch between controlled and uncontrolled component', () => {
   const wrapper = mount(
     <ExpandCollapsePanel animationTiming={0}>
       <PanelTrigger />

--- a/demo/patterns/components/ExpandCollapsePanel/index.js
+++ b/demo/patterns/components/ExpandCollapsePanel/index.js
@@ -1,6 +1,19 @@
-import React, { Component } from 'react';
+import React, { Component, useState } from 'react';
 import Highlight from '../../../Highlight';
 import { ExpandCollapsePanel, PanelTrigger } from 'src/';
+
+const ControlledExpandCollapse = () => {
+  const [open, setOpen] = useState(false);
+  return (
+    <ExpandCollapsePanel open={open} onToggle={() => setOpen(!open)}>
+      <PanelTrigger>More bacon info</PanelTrigger>
+      Bacon ipsum dolor amet chicken frankfurter shoulder strip steak kielbasa
+      ribeye ham hamburger. Fatback kielbasa shoulder, jowl buffalo bacon jerky
+      ham pancetta. Strip steak pig chicken, spare ribs buffalo beef tail ground
+      round. Pancetta kevin strip steak bacon beef corned beef venison.
+    </ExpandCollapsePanel>
+  );
+};
 
 export default class Demo extends Component {
   render() {
@@ -16,10 +29,33 @@ export default class Demo extends Component {
           beef tail ground round. Pancetta kevin strip steak bacon beef corned
           beef venison.
         </ExpandCollapsePanel>
+        <h3>Controlled Component</h3>
+        <p>
+          If you need to manually control the open/closed state of the panel,
+          you can do this by setting the <code>open</code> prop and handling
+          changes with <code>onToggle</code>.
+        </p>
+        <ControlledExpandCollapse />
         <h2>Code Sample</h2>
         <Highlight language="javascript">{`
-import React from 'react';
-import { ExpandCollapsePanel, PanelTrigger } from 'react-cauldron';
+import React, { useState } from 'react';
+import { ExpandCollapsePanel, PanelTrigger } from 'cauldron-react';
+
+const ControlledExpandCollapsePanel = () => {
+  const [ open, setOpen ] = useState(false)
+  return (
+    <ExpandCollapsePanel open={open} onToggle={() => setOpen(!open)}>
+      <PanelTrigger>
+        More bacon info
+      </PanelTrigger>
+      Bacon ipsum dolor amet chicken frankfurter shoulder strip steak
+      kielbasa ribeye ham hamburger. Fatback kielbasa shoulder, jowl buffalo
+      bacon jerky ham pancetta. Strip steak pig chicken, spare ribs buffalo
+      beef tail ground round. Pancetta kevin strip steak bacon beef corned
+      beef venison.
+    </ExpandCollapsePanel>
+  )
+}
 
 const Demo = () => {
   <ExpandCollapsePanel>
@@ -32,6 +68,7 @@ const Demo = () => {
     beef tail ground round. Pancetta kevin strip steak bacon beef corned
     beef venison.
   </ExpandCollapsePanel>
+  <ControlledExpandCollapsePanel />
 };
         `}</Highlight>
       </div>

--- a/src/components/ExpandCollapsePanel/ExpandCollapsePanel.js
+++ b/src/components/ExpandCollapsePanel/ExpandCollapsePanel.js
@@ -10,6 +10,7 @@ import {
 
 export default class ExpandCollapsePanel extends React.Component {
   static propTypes = {
+    open: PropTypes.bool,
     children: PropTypes.node.isRequired,
     className: PropTypes.string,
     animationTiming: PropTypes.oneOfType([PropTypes.number, PropTypes.bool]),
@@ -17,7 +18,8 @@ export default class ExpandCollapsePanel extends React.Component {
   };
 
   state = {
-    isOpen: false
+    controlled: typeof this.props.open !== 'undefined',
+    isOpen: typeof this.props.open !== 'undefined' ? this.props.open : false
   };
 
   static defaultProps = {
@@ -29,9 +31,11 @@ export default class ExpandCollapsePanel extends React.Component {
 
   handleToggle = e => {
     const { onToggle } = this.props;
-    const { isOpen } = this.state;
+    const { isOpen, controlled } = this.state;
     onToggle(e);
-    this.setState({ isOpen: !isOpen, isAnimating: true });
+    if (!controlled) {
+      this.setState({ isOpen: !isOpen, isAnimating: true });
+    }
   };
 
   animateOpen = () => {
@@ -76,16 +80,19 @@ export default class ExpandCollapsePanel extends React.Component {
   animateClose = () => {
     const { current: panel } = this.panel;
     const { animationTiming } = this.props;
-    const { styleTag } = this;
 
     if (!animationTiming) {
       this.setState({ isAnimating: false });
       return;
     }
 
+    if (!this.styleTag) {
+      this.styleTag = injectStyleTag();
+    }
+
     const rect = panel.getBoundingClientRect();
     setStyle(
-      styleTag,
+      this.styleTag,
       `
       @keyframes collapseCloseAnimation {
         0% { opacity: 1; height: ${rect.height}px; }
@@ -103,7 +110,7 @@ export default class ExpandCollapsePanel extends React.Component {
     this.setState({ animationClass: 'cauldron-collapse-close' }, () => {
       setTimeout(() => {
         this.setState({ animationClass: '', isAnimating: false });
-        setStyle(styleTag, '');
+        setStyle(this.styleTag, '');
       }, animationTiming);
     });
   };
@@ -116,10 +123,16 @@ export default class ExpandCollapsePanel extends React.Component {
   }
 
   componentDidUpdate(prevProps, prevState) {
-    const { isOpen } = this.state;
-    if (prevState.isOpen !== isOpen && isOpen) {
+    const { isOpen: openState, controlled } = this.state;
+    const { open: openProp } = this.props;
+
+    if (controlled && openState !== openProp) {
+      this.setState({ isOpen: openProp, isAnimating: true });
+    }
+
+    if (prevState.isOpen !== openState && openState) {
       this.animateOpen();
-    } else if (prevState.isOpen !== isOpen && !isOpen) {
+    } else if (prevState.isOpen !== openState && !openState) {
       this.animateClose();
     }
   }
@@ -131,6 +144,7 @@ export default class ExpandCollapsePanel extends React.Component {
       animationTiming,
       className,
       onToggle,
+      open,
       ...other
     } = this.props;
     /* eslint-enable no-unused-vars */

--- a/src/components/ExpandCollapsePanel/ExpandCollapsePanel.js
+++ b/src/components/ExpandCollapsePanel/ExpandCollapsePanel.js
@@ -130,6 +130,10 @@ export default class ExpandCollapsePanel extends React.Component {
       this.setState({ isOpen: openProp, isAnimating: true });
     }
 
+    if (typeof openProp !== typeof prevProps.open) {
+      this.setState({ controlled: typeof openProp !== 'undefined' });
+    }
+
     if (prevState.isOpen !== openState && openState) {
       this.animateOpen();
     } else if (prevState.isOpen !== openState && !openState) {

--- a/types.d.ts
+++ b/types.d.ts
@@ -335,6 +335,7 @@ export const ClickOutsideListener: React.ComponentType<
 
 interface ExpandCollapsePanelProps
   extends React.HTMLAttributes<HTMLDivElement> {
+  open?: boolean;
   children: React.ReactNode;
   animationTiming?: number | boolean;
   onToggle?: (e: React.MouseEvent<HTMLButtonElement>) => void;


### PR DESCRIPTION
Allows for `<ExpandCollapsePanel />` to be controlled with an optional `open` prop.

Needed for dequelabs/attest-browser-extensions#716.

Closes #153