### PR TITLE
ci: publish @next from develop, @latest from master

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,4 +67,4 @@ workflows:
             - tests
           filters:
             branches:
-              ignore: master
+              only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,16 +58,13 @@ workflows:
             - dependencies
             - tests
           filters:
-            # Make an "unstable" release when a commit lands in master.
+            # Make an "unstable" release when a commit lands in develop.
             branches:
-              only: master
+              only: develop
       - release:
           requires:
             - dependencies
             - tests
           filters:
-            # Make a "stable" release when SEMVER-ish tags are pushed.
-            tags:
-              only: /^v?[0-9]+(\.[0-9]+)*(-.+)?/
             branches:
-              ignore: /.*/
+              ignore: master

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ $ yarn test --watch
 
 ## Publishing
 
-Publishing `cauldron-react` to the npm registry is handled by CircleCI. All (green) commits that land in the `master` branch will be released as a "canary" version (eg `1.2.3-canary.GIT_SHA`) and will be available with the `@next` dist tag. Additionally, all (green) tags that resemble a SEMVER version will be published as stable versions (eg `1.2.3`) and available with the `@latest` dist tag.
+Publishing `cauldron-react` to the npm registry is handled by CircleCI. All (green) commits that land in the `develop` branch will be released as a "canary" version (eg `1.2.3-canary.GIT_SHA`) and will be available with the `@next` dist tag. Additionally, all (green) `master` commits will be published as stable versions (eg `1.2.3`) and available with the `@latest` dist tag.
 
 To install the latest canary version, do: `npm install cauldron-react@next`. To install the latest stable version, do `npm install cauldron-react`.
 
@@ -50,10 +50,14 @@ To publish a stable version, you'll do something like this:
 
 ```
 # Ensure you have the latest code
-$ git checkout master
+$ git checkout develop
 $ git pull
+# Create a release branch
+$ git create-branch release-<YYYY-MM-DD>
 # Run the release script
 $ npm run release
 # push it
-$ git push --follow-tags origin master && npm publish
+$ git push --follow-tags origin release-<YYYY-MM-DD>
 ```
+
+Then open a release PR into the `master` branch.


### PR DESCRIPTION
This patch changes our workflow a bit, making it mirror pretty much every other repository we have. Once this is approved, I'll swap the default branch to "develop" and we'll begin working from it.

Releases are still handled by CircleCI, the only difference is `develop` commits result in `@next` being published and `master` commits publish `@latest`. There is no longer any CI magic for SEMVER-ish tags.