### PR TITLE
fix: remove duplicate ids from visible FTPO

### DIFF
--- a/__tests__/src/components/FirstTimePointOut/index.js
+++ b/__tests__/src/components/FirstTimePointOut/index.js
@@ -3,7 +3,7 @@ import { shallow, mount } from 'enzyme';
 import FirstTimePointOut from 'src/components/FirstTimePointOut';
 import { axe } from 'jest-axe';
 
-const defaults = { headingId: 'foo' };
+const defaults = {};
 
 test('handles "noArrow" prop properly', () => {
   expect.assertions(1);

--- a/__tests__/src/components/FirstTimePointOut/index.js
+++ b/__tests__/src/components/FirstTimePointOut/index.js
@@ -160,3 +160,26 @@ test('should return no axe violations', async () => {
 
   expect(await axe(ftpo.html())).toHaveNoViolations();
 });
+
+test('should return no axe violations when rendering via a portal', async () => {
+  const FTPOWithTarget = () => {
+    const elementRef = React.createRef();
+    return (
+      <React.Fragment>
+        <button type="button" ref={elementRef}>
+          Button
+        </button>
+        <FirstTimePointOut
+          {...defaults}
+          target={elementRef}
+          dismissText={'Dismiss'}
+        >
+          <h4 id="foo">Header</h4>
+        </FirstTimePointOut>
+      </React.Fragment>
+    );
+  };
+  const ftpo = mount(<FTPOWithTarget />);
+
+  expect(await axe(ftpo.html())).toHaveNoViolations();
+});

--- a/__tests__/src/components/FirstTimePointOut/index.js
+++ b/__tests__/src/components/FirstTimePointOut/index.js
@@ -3,7 +3,7 @@ import { shallow, mount } from 'enzyme';
 import FirstTimePointOut from 'src/components/FirstTimePointOut';
 import { axe } from 'jest-axe';
 
-const defaults = { headerId: 'foo' };
+const defaults = { headingId: 'foo' };
 
 test('handles "noArrow" prop properly', () => {
   expect.assertions(1);
@@ -116,19 +116,19 @@ test('should be positioned relative to target', () => {
   expect(left).toEqual('506px');
 });
 
-test('should associate FTPO with header id', () => {
+test('should associate FTPO with heading id', () => {
   const ftpo = mount(
-    <FirstTimePointOut header={<h4>Header</h4>} {...defaults}>
+    <FirstTimePointOut heading={<h4>heading</h4>} {...defaults}>
       {'hello'}
     </FirstTimePointOut>
   );
   ftpo.update();
 
-  const header = ftpo.find('h4');
+  const heading = ftpo.find('h4');
   const wrap = ftpo.find('.dqpl-pointer-wrap');
 
-  expect(typeof header.prop('id') === 'string').toBeTruthy();
-  expect(header.prop('id')).toEqual(wrap.prop('aria-labelledby'));
+  expect(typeof heading.prop('id') === 'string').toBeTruthy();
+  expect(heading.prop('id')).toEqual(wrap.prop('aria-labelledby'));
 });
 
 test('should mirror focus to visual FTPO', () => {
@@ -176,7 +176,7 @@ test('should clean ids from portal FTPO', () => {
         </button>
         <FirstTimePointOut
           {...defaults}
-          header={<h4>Header</h4>}
+          heading={<h4>heading</h4>}
           target={elementRef}
           dismissText={'Dismiss'}
         >
@@ -198,7 +198,7 @@ test('should return no axe violations', async () => {
   const ftpo = mount(
     <FirstTimePointOut
       {...defaults}
-      header={<h4>Header</h4>}
+      heading={<h4>heading</h4>}
       dismissText={'Dismiss'}
     >
       Body
@@ -218,7 +218,7 @@ test('should return no axe violations when rendering via a portal', async () => 
         </button>
         <FirstTimePointOut
           {...defaults}
-          header={<h4>Header</h4>}
+          heading={<h4>heading</h4>}
           target={elementRef}
           dismissText={'Dismiss'}
         >

--- a/__tests__/src/components/FirstTimePointOut/index.js
+++ b/__tests__/src/components/FirstTimePointOut/index.js
@@ -116,6 +116,21 @@ test('should be positioned relative to target', () => {
   expect(left).toEqual('506px');
 });
 
+test('should associate FTPO with header id', () => {
+  const ftpo = mount(
+    <FirstTimePointOut header={<h4>Header</h4>} {...defaults}>
+      {'hello'}
+    </FirstTimePointOut>
+  );
+  ftpo.update();
+
+  const header = ftpo.find('h4');
+  const wrap = ftpo.find('.dqpl-pointer-wrap');
+
+  expect(typeof header.prop('id') === 'string').toBeTruthy();
+  expect(header.prop('id')).toEqual(wrap.prop('aria-labelledby'));
+});
+
 test('should mirror focus to visual FTPO', () => {
   const ftpo = mount(
     <FirstTimePointOut
@@ -151,10 +166,42 @@ test('should mirror focus to visual FTPO', () => {
   ).toBeTruthy();
 });
 
+test('should clean ids from portal FTPO', () => {
+  const FTPOWithTarget = () => {
+    const elementRef = React.createRef();
+    return (
+      <React.Fragment>
+        <button type="button" ref={elementRef}>
+          Button
+        </button>
+        <FirstTimePointOut
+          {...defaults}
+          header={<h4>Header</h4>}
+          target={elementRef}
+          dismissText={'Dismiss'}
+        >
+          Body
+          <p id="foo" />
+        </FirstTimePointOut>
+      </React.Fragment>
+    );
+  };
+  const ftpo = mount(<FTPOWithTarget />);
+  const offscreenFtpo = ftpo.find('.dqpl-offscreen .dqpl-content');
+  const portalFtpo = ftpo.find('Portal .dqpl-content');
+
+  expect(offscreenFtpo.exists('#foo')).toBeTruthy();
+  expect(portalFtpo.exists('#foo')).toBeFalsy();
+});
+
 test('should return no axe violations', async () => {
   const ftpo = mount(
-    <FirstTimePointOut {...defaults} dismissText={'Dismiss'}>
-      <h4 id="foo">Header</h4>
+    <FirstTimePointOut
+      {...defaults}
+      header={<h4>Header</h4>}
+      dismissText={'Dismiss'}
+    >
+      Body
     </FirstTimePointOut>
   );
 
@@ -171,15 +218,15 @@ test('should return no axe violations when rendering via a portal', async () => 
         </button>
         <FirstTimePointOut
           {...defaults}
+          header={<h4>Header</h4>}
           target={elementRef}
           dismissText={'Dismiss'}
         >
-          <h4 id="foo">Header</h4>
+          Body
         </FirstTimePointOut>
       </React.Fragment>
     );
   };
   const ftpo = mount(<FTPOWithTarget />);
-
   expect(await axe(ftpo.html())).toHaveNoViolations();
 });

--- a/__tests__/src/utils/remove-ids/index.js
+++ b/__tests__/src/utils/remove-ids/index.js
@@ -1,0 +1,29 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import removeIds from '../../../../src/utils/remove-ids';
+
+test('should remove id from rendered node', () => {
+  const Foo = () => removeIds(<div id="foo" />);
+  const wrapper = mount(<Foo />);
+  expect(wrapper.find('div').prop('id')).toBeFalsy();
+});
+
+test('should remove id from rendered child nodes', () => {
+  const Foo = () =>
+    removeIds(
+      <div>
+        <div id="foo1" />
+        <div id="foo2" />
+      </div>
+    );
+  const wrapper = mount(<Foo />);
+  const [foo1, foo2] = wrapper.find('div > div').map(child => child);
+  expect(foo1.prop('id')).toBeFalsy();
+  expect(foo2.prop('id')).toBeFalsy();
+});
+
+test('should allow other props to persist', () => {
+  const Foo = () => removeIds(<div id="foo" className="bar" />);
+  const wrapper = mount(<Foo />);
+  expect(wrapper.find('div').prop('className')).toEqual('bar');
+});

--- a/demo/patterns/components/FirstTimePointOut/index.js
+++ b/demo/patterns/components/FirstTimePointOut/index.js
@@ -23,41 +23,43 @@ const Demo = () => {
       <h2>Demo</h2>
 
       <h3>With Default Arrow</h3>
-      <FirstTimePointOut headerId="ftpo-head-pointer" dismissText="Close">
-        <h4 id="ftpo-head-pointer">First time point out!</h4>
+      <FirstTimePointOut
+        header={<h4>First time point out!</h4>}
+        dismissText="Close"
+      >
         <p>This is a first time point out with a pointer</p>
       </FirstTimePointOut>
       <Highlight language="javascript">
-        {`<FirstTimePointOut headerId="ftpo-head-pointer" dismissText="Close">
-  <h4 id="ftpo-head-pointer">First time point out!</h4>
+        {`<FirstTimePointOut header={<h4>First time point out!</h4>} dismissText="Close">
   <p>This is a first time point out with a pointer</p>
 </FirstTimePointOut>`}
       </Highlight>
 
       <h3>With Positioned Arrow</h3>
       <FirstTimePointOut
-        headerId="ftpo-head-positioned"
+        header={<h4>First time point out!</h4>}
         dismissText="Close"
         arrowPosition="top-right"
       >
-        <h4 id="ftpo-head-positioned">First time point out!</h4>
         <p>This is a first time point out with a positioned pointer</p>
       </FirstTimePointOut>
       <Highlight language="javascript">
-        {`<FirstTimePointOut headerId="ftpo-head-positioned" dismissText="Close" arrowPosition="top-right>
-  <h4 id="ftpo-head-positioned">First time point out!</h4>
+        {`<FirstTimePointOut
+  header={<h4>First time point out!</h4>}
+  dismissText="Close"
+  arrowPosition="top-right"
+>
   <p>This is a first time point out with a positioned pointer</p>
 </FirstTimePointOut>`}
       </Highlight>
 
       <h3>Without Arrow</h3>
-      <FirstTimePointOut headerId="ftpo-head-no-arrow" noArrow={true}>
-        <h4 id="ftpo-head-no-arrow">First time point out!</h4>
+      <FirstTimePointOut header={<h4>First time point out!</h4>} noArrow={true}>
         <p>This is a first time point out without a pointer</p>
       </FirstTimePointOut>
       <Highlight language="javascript">
-        {`<FirstTimePointOut headerId="ftpo-head-no-arrow" noArrow={true}>
-  <h4 id="ftpo-head-no-arrow">First time point out!</h4>
+        {`<FirstTimePointOut header={<h4>First time point out!</h4>} noArrow={true}>
+  <h4>First time point out!</h4>
   <p>This is a first time point out without a pointer</p>
 </FirstTimePointOut>`}
       </Highlight>
@@ -80,6 +82,14 @@ const Demo = () => {
         can call <code>forceUpdate()</code> on the First Time Point out to reset
         the positioning.
       </p>
+      <p>
+        Please be aware that when using a <code>target</code> prop, the First
+        Time Point Out&#39;s children are duplicated in order to address
+        accessibility concerns. Any ids that are present in children will be
+        sanitized in order to prevent duplicate ids from existing in the DOM.
+        These ids will not be available to style, so it&#39;s recommended that
+        you use classes or attribute to target styling instead.
+      </p>
 
       <button
         style={{ marginLeft: `${position}%`, marginBottom: '171px' }}
@@ -92,12 +102,11 @@ const Demo = () => {
       </button>
       <FirstTimePointOut
         ref={ftpoRef}
-        headerId="ftpo-head"
+        header={<h4>Targeted FTPO</h4>}
         dismissText="Close"
         target={buttonRef}
         portal={portal}
       >
-        <h4 id="ftpo-head">Targeted FTPO</h4>
         <p>This is a first time point out pointing to an element target.</p>
       </FirstTimePointOut>
       <Highlight language="javascript">
@@ -106,8 +115,7 @@ const Demo = () => {
   return (
     <div>
       <button type="button" ref={buttonRef}>Button</button>
-      <FirstTimePointOut headerId="ftpo-targeted" dismissText="Close" target={buttonRef}>
-        <h4 id="ftpo-targeted">Targeted FTPO</h4>
+      <FirstTimePointOut header={<h4>Targeted FTPO</h4>} dismissText="Close" target={buttonRef}
         <p>This is a first time point out pointing to an element target.</p>
       </FirstTimePointOut>
     </div>

--- a/demo/patterns/components/FirstTimePointOut/index.js
+++ b/demo/patterns/components/FirstTimePointOut/index.js
@@ -24,20 +24,20 @@ const Demo = () => {
 
       <h3>With Default Arrow</h3>
       <FirstTimePointOut
-        header={<h4>First time point out!</h4>}
+        heading={<h4>First time point out!</h4>}
         dismissText="Close"
       >
         <p>This is a first time point out with a pointer</p>
       </FirstTimePointOut>
       <Highlight language="javascript">
-        {`<FirstTimePointOut header={<h4>First time point out!</h4>} dismissText="Close">
+        {`<FirstTimePointOut heading={<h4>First time point out!</h4>} dismissText="Close">
   <p>This is a first time point out with a pointer</p>
 </FirstTimePointOut>`}
       </Highlight>
 
       <h3>With Positioned Arrow</h3>
       <FirstTimePointOut
-        header={<h4>First time point out!</h4>}
+        heading={<h4>First time point out!</h4>}
         dismissText="Close"
         arrowPosition="top-right"
       >
@@ -45,7 +45,7 @@ const Demo = () => {
       </FirstTimePointOut>
       <Highlight language="javascript">
         {`<FirstTimePointOut
-  header={<h4>First time point out!</h4>}
+  heading={<h4>First time point out!</h4>}
   dismissText="Close"
   arrowPosition="top-right"
 >
@@ -54,11 +54,14 @@ const Demo = () => {
       </Highlight>
 
       <h3>Without Arrow</h3>
-      <FirstTimePointOut header={<h4>First time point out!</h4>} noArrow={true}>
+      <FirstTimePointOut
+        heading={<h4>First time point out!</h4>}
+        noArrow={true}
+      >
         <p>This is a first time point out without a pointer</p>
       </FirstTimePointOut>
       <Highlight language="javascript">
-        {`<FirstTimePointOut header={<h4>First time point out!</h4>} noArrow={true}>
+        {`<FirstTimePointOut heading={<h4>First time point out!</h4>} noArrow={true}>
   <h4>First time point out!</h4>
   <p>This is a first time point out without a pointer</p>
 </FirstTimePointOut>`}
@@ -107,7 +110,7 @@ const Demo = () => {
       </button>
       <FirstTimePointOut
         ref={ftpoRef}
-        header={<h4>Targeted FTPO</h4>}
+        heading={<h4>Targeted FTPO</h4>}
         dismissText="Close"
         target={buttonRef}
         portal={portal}
@@ -120,7 +123,7 @@ const Demo = () => {
   return (
     <div>
       <button type="button" ref={buttonRef}>Button</button>
-      <FirstTimePointOut header={<h4>Targeted FTPO</h4>} dismissText="Close" target={buttonRef}
+      <FirstTimePointOut heading={<h4>Targeted FTPO</h4>} dismissText="Close" target={buttonRef}
         <p>This is a first time point out pointing to an element target.</p>
       </FirstTimePointOut>
     </div>

--- a/demo/patterns/components/FirstTimePointOut/index.js
+++ b/demo/patterns/components/FirstTimePointOut/index.js
@@ -90,6 +90,11 @@ const Demo = () => {
         These ids will not be available to style, so it&#39;s recommended that
         you use classes or attribute to target styling instead.
       </p>
+      <p>
+        <strong>NOTE:</strong> Any ids/attributes of children will be applied to
+        the offscreen/screen-reader-only ftpo, so things like aria-labelledby
+        and aria-describedby etc will still work as expected.
+      </p>
 
       <button
         style={{ marginLeft: `${position}%`, marginBottom: '171px' }}

--- a/src/components/FirstTimePointOut/index.js
+++ b/src/components/FirstTimePointOut/index.js
@@ -2,13 +2,14 @@ import React, { Component } from 'react';
 import { createPortal } from 'react-dom';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
+import rndid from '../../utils/rndid';
 import removeIds from '../../utils/remove-ids';
 
 const __Element = typeof Element === 'undefined' ? function() {} : Element;
 
 export default class FirstTimePointOut extends Component {
   static propTypes = {
-    headerId: PropTypes.string.isRequired,
+    header: PropTypes.node,
     children: PropTypes.node.isRequired,
     ftpRef: PropTypes.func,
     noArrow: function(props, propName) {
@@ -47,6 +48,8 @@ export default class FirstTimePointOut extends Component {
     const { positionRelativeToTarget, attachOffscreenListeners } = this;
 
     positionRelativeToTarget();
+
+    this.setState({ headerId: rndid() });
 
     // debounce resize event to rAF
     this.resizeDebounce = () => {
@@ -232,7 +235,8 @@ export default class FirstTimePointOut extends Component {
     const { props, attachOffscreenListeners, positionRelativeToTarget } = this;
     if (
       props.arrowPosition !== nextProps.arrowPosition ||
-      props.portal !== nextProps.portal
+      props.portal !== nextProps.portal ||
+      props.target !== nextProps.target
     ) {
       attachOffscreenListeners();
       positionRelativeToTarget();
@@ -244,10 +248,11 @@ export default class FirstTimePointOut extends Component {
       show,
       style,
       offscreenButtonFocus,
-      offscreenContentFocus
+      offscreenContentFocus,
+      headerId
     } = this.state;
     const {
-      headerId,
+      header,
       ftpRef,
       children,
       noArrow,
@@ -271,7 +276,7 @@ export default class FirstTimePointOut extends Component {
         })}
         style={style}
         role="region"
-        aria-labelledby={headerId}
+        aria-labelledby={header ? headerId : null}
         aria-hidden={!!target}
       >
         {noArrow ? null : (
@@ -302,7 +307,9 @@ export default class FirstTimePointOut extends Component {
             tabIndex={!target ? -1 : null}
             ref={ftpRef}
           >
-            {children}
+            {header &&
+              React.cloneElement(header, { id: target ? null : headerId })}
+            {target ? removeIds(children) : children}
           </div>
           {/* eslint-enable jsx-a11y/no-noninteractive-tabindex */}
         </div>
@@ -312,7 +319,10 @@ export default class FirstTimePointOut extends Component {
     if (target && portal) {
       return (
         <React.Fragment>
-          <div className="dqpl-offscreen" aria-labelledby={headerId}>
+          <div
+            className="dqpl-offscreen"
+            aria-labelledby={header ? headerId : null}
+          >
             <button
               type="button"
               ref={el => (this.offscreenButtonRef = el)}
@@ -324,11 +334,11 @@ export default class FirstTimePointOut extends Component {
               tabIndex="-1"
               ref={el => (this.offscreenContentRef = el)}
             >
+              {header && React.cloneElement(header, { id: headerId })}
               {children}
             </div>
           </div>
-          {/* remove ids in the visible FTPO as they may be duplicated in the hidden children above */}
-          {createPortal(removeIds(FTPO), portal)}
+          {createPortal(FTPO, portal)}
         </React.Fragment>
       );
     }

--- a/src/components/FirstTimePointOut/index.js
+++ b/src/components/FirstTimePointOut/index.js
@@ -2,6 +2,7 @@ import React, { Component } from 'react';
 import { createPortal } from 'react-dom';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
+import removeIds from '../../utils/remove-ids';
 
 const __Element = typeof Element === 'undefined' ? function() {} : Element;
 
@@ -311,7 +312,7 @@ export default class FirstTimePointOut extends Component {
     if (target && portal) {
       return (
         <React.Fragment>
-          <div className="dqpl-offscreen">
+          <div className="dqpl-offscreen" aria-labelledby={headerId}>
             <button
               type="button"
               ref={el => (this.offscreenButtonRef = el)}
@@ -326,7 +327,8 @@ export default class FirstTimePointOut extends Component {
               {children}
             </div>
           </div>
-          {createPortal(FTPO, portal)}
+          {/* remove ids in the visible FTPO as they may be duplicated in the hidden children above */}
+          {createPortal(removeIds(FTPO), portal)}
         </React.Fragment>
       );
     }

--- a/src/components/FirstTimePointOut/index.js
+++ b/src/components/FirstTimePointOut/index.js
@@ -275,7 +275,7 @@ export default class FirstTimePointOut extends Component {
           [arrowPosition]: !!arrowPosition && !noArrow
         })}
         style={style}
-        role="region"
+        role={target ? null : 'region'}
         aria-labelledby={header ? headerId : null}
         aria-hidden={!!target}
       >
@@ -321,6 +321,7 @@ export default class FirstTimePointOut extends Component {
         <React.Fragment>
           <div
             className="dqpl-offscreen"
+            role="region"
             aria-labelledby={header ? headerId : null}
           >
             <button

--- a/src/components/FirstTimePointOut/index.js
+++ b/src/components/FirstTimePointOut/index.js
@@ -9,7 +9,7 @@ const __Element = typeof Element === 'undefined' ? function() {} : Element;
 
 export default class FirstTimePointOut extends Component {
   static propTypes = {
-    header: PropTypes.node,
+    heading: PropTypes.node,
     children: PropTypes.node.isRequired,
     ftpRef: PropTypes.func,
     noArrow: function(props, propName) {
@@ -49,7 +49,7 @@ export default class FirstTimePointOut extends Component {
 
     positionRelativeToTarget();
 
-    this.setState({ headerId: rndid() });
+    this.setState({ headingId: rndid() });
 
     // debounce resize event to rAF
     this.resizeDebounce = () => {
@@ -249,10 +249,10 @@ export default class FirstTimePointOut extends Component {
       style,
       offscreenButtonFocus,
       offscreenContentFocus,
-      headerId
+      headingId
     } = this.state;
     const {
-      header,
+      heading,
       ftpRef,
       children,
       noArrow,
@@ -276,7 +276,7 @@ export default class FirstTimePointOut extends Component {
         })}
         style={style}
         role={target ? null : 'region'}
-        aria-labelledby={header ? headerId : null}
+        aria-labelledby={heading ? headingId : null}
         aria-hidden={!!target}
       >
         {noArrow ? null : (
@@ -307,8 +307,8 @@ export default class FirstTimePointOut extends Component {
             tabIndex={!target ? -1 : null}
             ref={ftpRef}
           >
-            {header &&
-              React.cloneElement(header, { id: target ? null : headerId })}
+            {heading &&
+              React.cloneElement(heading, { id: target ? null : headingId })}
             {target ? removeIds(children) : children}
           </div>
           {/* eslint-enable jsx-a11y/no-noninteractive-tabindex */}
@@ -322,7 +322,7 @@ export default class FirstTimePointOut extends Component {
           <div
             className="dqpl-offscreen"
             role="region"
-            aria-labelledby={header ? headerId : null}
+            aria-labelledby={heading ? headingId : null}
           >
             <button
               type="button"
@@ -335,7 +335,7 @@ export default class FirstTimePointOut extends Component {
               tabIndex="-1"
               ref={el => (this.offscreenContentRef = el)}
             >
-              {header && React.cloneElement(header, { id: headerId })}
+              {heading && React.cloneElement(heading, { id: headingId })}
               {children}
             </div>
           </div>

--- a/src/utils/remove-ids/index.js
+++ b/src/utils/remove-ids/index.js
@@ -1,0 +1,25 @@
+import { Children, isValidElement, cloneElement } from 'react';
+
+/*
+ * Recursively walks React element tree removing any id props for descendant nodes
+ */
+function recursivelyRemoveIds(element) {
+  const walker = element => {
+    if (!isValidElement(element)) {
+      return element;
+    }
+
+    return cloneElement(
+      element,
+      {
+        // we can't remove attributes, but react treats undefined/null as "absent"
+        id: null
+      },
+      Children.map(element.props.children, childElement => walker(childElement))
+    );
+  };
+
+  return walker(element);
+}
+
+export default recursivelyRemoveIds;

--- a/src/utils/remove-ids/index.js
+++ b/src/utils/remove-ids/index.js
@@ -19,7 +19,9 @@ function recursivelyRemoveIds(element) {
     );
   };
 
-  return walker(element);
+  return Array.isArray(element)
+    ? Children.map(element, walker)
+    : walker(element);
 }
 
 export default recursivelyRemoveIds;


### PR DESCRIPTION
I realized that the targeted FTPO had duplicate ids due to `children` being rendered twice. This adds a util to remove those ids from the visible FTPO only when it's being duplicated to a portal.