### PR TITLE
fix(Select): correct `onSelect` TypeScript definition

### DIFF
--- a/types.d.ts
+++ b/types.d.ts
@@ -261,7 +261,7 @@ interface SelectProps {
   selectedId: string;
   className?: string;
   onKeyDown?: (e: React.KeyboardEvent<HTMLDivElement>) => void;
-  onSelect?: (value: any) => void;
+  onSelect?: (option: SelectOption) => void;
   required?: boolean;
   value?: string;
 }


### PR DESCRIPTION
The `Select` component's `onSelect` callback receives a `SelectOption`, not a "value".