### PR TITLE
DO NOT MERGE  wrap <Select/> in a <form> to demonstrate a bug

### DIFF
--- a/demo/patterns/components/Select/index.js
+++ b/demo/patterns/components/Select/index.js
@@ -39,7 +39,7 @@ export default class Demo extends Component {
       <div className="select-demo">
         <h1>Select</h1>
         <h2>Demo</h2>
-        <div>
+        <form onSubmit={this.handleSubmit}>
           <Select
             label="Day"
             value={this.state.value}
@@ -69,7 +69,7 @@ export default class Demo extends Component {
             <strong>Current value: </strong>
             <span>{this.state.current}</span>
           </div>
-        </div>
+        </form>
         <h2>Code Sample</h2>
         <Highlight language="javascript">
           {`
@@ -97,4 +97,9 @@ export default class Demo extends Component {
       </div>
     );
   }
+
+  handleSubmit = e => {
+    e.preventDefault();
+    alert('form submitted');
+  };
 }


### PR DESCRIPTION
This patch demonstrates a bug where selecting an option of a `<Select/>` submits its parent form.

You can see the bug at https://deploy-preview-186--cauldron-react.netlify.com/components/select. If you use a mouse and select any of the options, an `alert()` will appear.