### PR TITLE
fix(Select): prevent unwanted <form> submissions 

### DIFF
--- a/demo/patterns/components/Select/index.js
+++ b/demo/patterns/components/Select/index.js
@@ -39,7 +39,7 @@ export default class Demo extends Component {
       <div className="select-demo">
         <h1>Select</h1>
         <h2>Demo</h2>
-        <div>
+        <form onSubmit={this.handleSubmit}>
           <Select
             label="Day"
             value={this.state.value}
@@ -69,7 +69,7 @@ export default class Demo extends Component {
             <strong>Current value: </strong>
             <span>{this.state.current}</span>
           </div>
-        </div>
+        </form>
         <h2>Code Sample</h2>
         <Highlight language="javascript">
           {`
@@ -97,4 +97,9 @@ export default class Demo extends Component {
       </div>
     );
   }
+
+  handleSubmit = e => {
+    e.preventDefault();
+    alert('form submitted');
+  };
 }

--- a/src/components/Select/index.js
+++ b/src/components/Select/index.js
@@ -282,7 +282,8 @@ export default class Select extends Component {
     this.props.onKeyDown(e);
   }
 
-  onClick() {
+  onClick(e) {
+    e.preventDefault();
     this.setState(
       {
         expanded: !this.state.expanded

--- a/src/components/Select/index.js
+++ b/src/components/Select/index.js
@@ -283,7 +283,12 @@ export default class Select extends Component {
   }
 
   onClick(e) {
-    e.preventDefault();
+    // Prevent the click from triggering other events (see #188).
+    // NOTE: this method is invoked without an event (`e`) elsewhere.
+    if (e) {
+      e.preventDefault();
+    }
+
     this.setState(
       {
         expanded: !this.state.expanded

--- a/src/components/Select/index.js
+++ b/src/components/Select/index.js
@@ -161,6 +161,7 @@ export default class Select extends Component {
             onClick={this.onClick}
             ref={select => (this.select = select)}
             onKeyDown={this.onTriggerKeydown}
+            type="button"
           >
             {pseudoVal}
           </button>
@@ -282,13 +283,7 @@ export default class Select extends Component {
     this.props.onKeyDown(e);
   }
 
-  onClick(e) {
-    // Prevent the click from triggering other events (see #188).
-    // NOTE: this method is invoked without an event (`e`) elsewhere.
-    if (e) {
-      e.preventDefault();
-    }
-
+  onClick() {
     this.setState(
       {
         expanded: !this.state.expanded


### PR DESCRIPTION
This patch prevents the `<button>` used within `<Select>` from submitting a `<form>`. The button would submit the form because its [`type` attribute was not specified and the default type is "_submit_"](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#attr-type). By setting `type="button"`, we prevent the form submission.

Closes #188 and #186