### PR TITLE
fix(TextField): properly implement `HTMLInputElement` props

### DIFF
--- a/__tests__/typechecks.tsx
+++ b/__tests__/typechecks.tsx
@@ -256,7 +256,15 @@ const textField = () => (
       requiredText="Required"
       aria-describedby="help-text"
     />
-    <TextField name="url" type="url" label="URL" />
+    <TextField name="url" type="url" label="URL" required />
+    <TextField
+      disabled
+      aria-label="foo"
+      label="banana"
+      id="potato"
+      value="sharks"
+      multiline
+    />
   </>
 );
 

--- a/types.d.ts
+++ b/types.d.ts
@@ -325,20 +325,15 @@ export const CardFooter: React.ComponentType<
   React.HTMLAttributes<HTMLDivElement>
 >;
 
-interface TextFieldProps {
+interface TextFieldProps
+  extends Omit<React.InputHTMLAttributes<HTMLInputElement>, 'onChange'> {
   label: React.ReactNode;
-  id?: string;
   error?: React.ReactNode;
   defaultValue?: string;
-  value?: string;
   onChange?: (value: string, e: React.ChangeEvent<HTMLInputElement>) => void;
   fieldRef?: RefCallback;
-  required?: boolean;
   requiredText?: string;
   multiline?: boolean;
-  'aria-describedby'?: string;
-  type?: string;
-  name?: string;
 }
 
 export const TextField: React.ComponentType<TextFieldProps>;


### PR DESCRIPTION
This patch enables standard `HTMLInputElement` properties on our `TextField` component.