### PR TITLE
feat: implement smaller ftpo arrows from pattern-library

### DIFF
--- a/demo/index.css
+++ b/demo/index.css
@@ -11,3 +11,8 @@ h3 {
 code {
   font-family: Consolas, Monaco, 'Andale Mono', 'Ubuntu Mono', monospace;
 }
+
+/* adjust ftpo positioning for demo layout */
+.dqpl-pointer-wrap:not(.dqpl-ftpo-auto) {
+  position: relative;
+}

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "babel-plugin-transform-export-extensions": "^6.22.0",
     "closest": "0.0.1",
     "css-loader": "^0.28.7",
-    "deque-pattern-library": "^6.1.0",
+    "deque-pattern-library": "^7.0.0",
     "enzyme": "^3.2.0",
     "enzyme-adapter-react-16": "^1.11.2",
     "eslint": "^4.12.1",

--- a/src/components/FirstTimePointOut/index.css
+++ b/src/components/FirstTimePointOut/index.css
@@ -2,10 +2,6 @@
   display: inline-block;
 }
 
-.dqpl-pointer-wrap.dqpl-ftpo-auto {
-  position: absolute;
-}
-
 /* TODO: this should probably live in pattern-library */
 .dqpl-focus-active {
   outline: #d71ef7 solid 2px;
@@ -17,102 +13,66 @@
   background: #283640;
 }
 
-.dqpl-pointer-wrap.dqpl-ftpo-auto .dqpl-arrow[class*='top-'],
-.dqpl-pointer-wrap.dqpl-ftpo-auto .dqpl-arrow[class*='bottom-'] {
-  top: 0;
-  bottom: 0;
+.dqpl-ftpo-auto[class*='top-'] {
+  margin-top: 42px;
 }
 
-.dqpl-ftpo-auto [class*='left-'].dqpl-arrow {
-  left: -14px;
+.dqpl-ftpo-auto[class*='bottom-'] {
+  margin-top: -44px;
 }
 
-.dqpl-ftpo-auto [class*='right-'].dqpl-arrow {
-  right: -12px;
-  z-index: 10; /* dqpl-box has an implicit z-index so we need this so the arrow is layered correctly */
+.dqpl-ftpo-auto[class*='left-'] {
+  margin-left: 44px;
 }
 
-/* we need to overwrite the middle arrow positions because of a pattern-library issue */
-/* see: https://github.com/dequelabs/pattern-library/issues/122 */
-.dqpl-ftpo-auto .dqpl-arrow.left-middle,
-.dqpl-ftpo-auto .dqpl-arrow.right-middle {
-  left: unset;
-  right: unset;
-  bottom: unset;
-  transform: unset;
-  top: 50%;
-}
-
-.dqpl-ftpo-auto .dqpl-arrow.left-middle {
-  left: 0;
-  transform: translateY(-50%) rotate(-90deg) translateY(-12px);
-}
-
-.dqpl-ftpo-auto .dqpl-arrow.right-middle {
-  right: 0;
-  transform: translateY(-50%) rotate(90deg) translateY(-12px);
-}
-
-.dqpl-ftpo-auto [class*='top-'] + .dqpl-box {
-  margin-top: 62px;
-}
-
-.dqpl-ftpo-auto [class*='bottom-'] + .dqpl-box {
-  margin-bottom: 62px;
-}
-
-.dqpl-ftpo-auto [class*='left-'] + .dqpl-box {
-  margin-left: 62px;
-}
-
-.dqpl-ftpo-auto [class*='right-'] + .dqpl-box {
-  transform: translateX(-62px);
+.dqpl-ftpo-auto[class*='right-'] {
+  margin-left: -44px;
 }
 
 .dqpl-ftpo-auto.top-left {
-  transform: translateX(-6px);
+  transform: translateX(-5px);
 }
 
 .dqpl-ftpo-auto.top-middle {
-  transform: translateX(-50%);
+  transform: translateX(-50%) translateX(2px);
 }
 
 .dqpl-ftpo-auto.top-right {
-  transform: translateX(calc(-100% + 6px));
+  transform: translateX(-100%) translateX(5px);
 }
 
 .dqpl-ftpo-auto.left-top {
-  transform: translateY(-6px);
+  transform: translateY(-5px);
 }
 
 .dqpl-ftpo-auto.left-middle {
-  transform: translateY(-50%);
+  transform: translateY(-50%) translateY(-2px);
 }
 
 .dqpl-ftpo-auto.left-bottom {
-  transform: translateY(calc(-100% + 6px));
+  transform: translateY(-100%) translateY(5px);
 }
 
 .dqpl-ftpo-auto.bottom-left {
-  transform: translateY(-100%) translateX(-6px);
+  transform: translateY(-100%) translateX(-5px);
 }
 
 .dqpl-ftpo-auto.bottom-middle {
-  transform: translateY(-100%) translateX(-50%);
+  transform: translateY(-100%) translateX(-50%) translateX(-2px);
 }
 
 .dqpl-ftpo-auto.bottom-right {
-  transform: translateY(-100%) translateX(calc(-100% + 6px));
+  transform: translateY(-100%) translateX(-100%) translateX(5px);
 }
 
 .dqpl-ftpo-auto.right-top {
-  transform: translateX(-100%) translateY(-6px);
+  transform: translateX(-100%) translateY(-5px);
 }
 
 .dqpl-ftpo-auto.right-middle {
-  transform: translateX(-100%) translateY(-50%);
+  transform: translateX(-100%) translateY(-50%) translateY(2px);
 }
 
 .dqpl-ftpo-auto.right-bottom {
-  transform: translateX(-100%) translateY(calc(-100% + 6px));
+  transform: translateX(-100%) translateY(-100%) translateY(5px);
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3394,10 +3394,10 @@ dependency-graph@^0.8.0:
   resolved "https://registry.yarnpkg.com/dependency-graph/-/dependency-graph-0.8.0.tgz#2da2d35ed852ecc24a5d6c17788ba57c3708755b"
   integrity sha512-DCvzSq2UiMsuLnj/9AL484ummEgLtZIcRS7YvtO38QnpX3vqh9nJ8P+zhu8Ja+SmLrBHO2iDbva20jq38qvBkQ==
 
-deque-pattern-library@^6.1.0:
-  version "6.1.0"
-  resolved "https://registry.yarnpkg.com/deque-pattern-library/-/deque-pattern-library-6.1.0.tgz#bd22c4e0fac7cd216e0f2161d90a033de2f27b34"
-  integrity sha512-m4zielwGO+byP9PxVwoJeTI2SR8tADVnlFBVCpRBOdcq9MxF+gNsWA0OhsEPP4MYvJrU0extz/pjhQGEWyprCQ==
+deque-pattern-library@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/deque-pattern-library/-/deque-pattern-library-7.0.0.tgz#66aecc0e1a1f3dab2dec258c2fcff97f9643b2b2"
+  integrity sha512-Yussy79QpYxV/VJj59wnuEFIePFxn8Hq7PnSCfJTyKH+vdp35tvemtc4rEnDcrnb7CYu0CGtjJAfuNcXw2nNHA==
 
 des.js@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
Updates to latest pattern library with smaller arrow size and re-adjusts the auto ftpo targeted positioning based on the smaller arrow size.

BREAKING CHANGE: FTPOs have new positioning and layout due to smaller arrows

Ref: dequelabs/pattern-library#124
Ref: dequelabs/pattern-library#118

![ftpo arrow demo example](https://user-images.githubusercontent.com/1062039/64209138-5a173580-ce65-11e9-8a2d-10f3639e081a.png)


## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**
- [x] Follows the commit message policy, appropriate for next version
- [x] Tested for accessibility
- [x] Code is reviewed for security
