### PR TITLE
fix(FTPO): allow inner content elements to mirror focus when using a target

### DIFF
--- a/__tests__/src/components/FirstTimePointOut/index.js
+++ b/__tests__/src/components/FirstTimePointOut/index.js
@@ -131,7 +131,7 @@ test('should associate FTPO with heading id', () => {
   expect(heading.prop('id')).toEqual(wrap.prop('aria-labelledby'));
 });
 
-test.skip('should mirror focus to visual FTPO', () => {
+test('should mirror focus to visual FTPO', () => {
   const ftpo = mount(
     <FirstTimePointOut
       {...defaults}
@@ -142,21 +142,30 @@ test.skip('should mirror focus to visual FTPO', () => {
         }
       }}
     >
-      {'hello'}
+      Hello <a href="#foo">Cruel World</a>
     </FirstTimePointOut>
   );
-  // the node that jest uses is not the same element in dom so this test fails
-  const hiddenButton = ftpo.find('button').at(0);
-  ftpo
-    .find('.dqpl-offscreen')
-    .getDOMNode()
-    .dispatchEvent(new Event('focusin', { target: hiddenButton.getDOMNode() }));
-  ftpo.update();
+
+  const offscreenFTPO = ftpo.find('.dqpl-offscreen');
+  const visibleFTPO = ftpo.find('.dqpl-pointer-wrap');
+  const [
+    offscreenFocusableButton,
+    offscreenFocusableAnchor
+  ] = ftpo.instance().getFocusableElements(offscreenFTPO.getDOMNode());
+  ftpo.instance().handleOffscreenFocusIn({ target: offscreenFocusableButton });
+  ftpo.instance().handleOffscreenFocusIn({ target: offscreenFocusableAnchor });
+
   expect(
-    ftpo
-      .find('button')
-      .at(1)
-      .hasClass('dqpl-focus-active')
+    visibleFTPO
+      .getDOMNode()
+      .querySelector('button')
+      .classList.contains('dqpl-focus-active')
+  ).toBeTruthy();
+  expect(
+    visibleFTPO
+      .getDOMNode()
+      .querySelector('a')
+      .classList.contains('dqpl-focus-active')
   ).toBeTruthy();
 
   const hiddenContent = ftpo.find('.dqpl-content').at(0);
@@ -168,6 +177,44 @@ test.skip('should mirror focus to visual FTPO', () => {
       .at(1)
       .hasClass('dqpl-content-focus-active')
   ).toBeTruthy();
+});
+
+test('should remove tabindex from focusable elements on visual FTPO with target', () => {
+  const ftpo = mount(
+    <FirstTimePointOut
+      {...defaults}
+      arrowPosition="top-left"
+      target={{
+        getBoundingClientRect() {
+          return { top: 0, left: 0, height: 0, width: 0 };
+        }
+      }}
+    >
+      Hello <a href="#foo">Cruel World</a>
+    </FirstTimePointOut>
+  );
+
+  const offscreenFTPO = ftpo.find('.dqpl-offscreen');
+  const visibleFTPO = ftpo.find('.dqpl-pointer-wrap');
+  const [
+    offscreenFocusableButton,
+    offscreenFocusableAnchor
+  ] = ftpo.instance().getFocusableElements(offscreenFTPO.getDOMNode());
+  ftpo.instance().handleOffscreenFocusIn({ target: offscreenFocusableButton });
+  ftpo.instance().handleOffscreenFocusIn({ target: offscreenFocusableAnchor });
+
+  expect(
+    visibleFTPO
+      .getDOMNode()
+      .querySelector('button')
+      .getAttribute('tabindex')
+  ).toEqual('-1');
+  expect(
+    visibleFTPO
+      .getDOMNode()
+      .querySelector('a')
+      .getAttribute('tabindex')
+  ).toEqual('-1');
 });
 
 test('should clean ids from portal FTPO', () => {

--- a/__tests__/src/components/FirstTimePointOut/index.js
+++ b/__tests__/src/components/FirstTimePointOut/index.js
@@ -131,7 +131,7 @@ test('should associate FTPO with heading id', () => {
   expect(heading.prop('id')).toEqual(wrap.prop('aria-labelledby'));
 });
 
-test('should mirror focus to visual FTPO', () => {
+test.skip('should mirror focus to visual FTPO', () => {
   const ftpo = mount(
     <FirstTimePointOut
       {...defaults}
@@ -145,8 +145,12 @@ test('should mirror focus to visual FTPO', () => {
       {'hello'}
     </FirstTimePointOut>
   );
+  // the node that jest uses is not the same element in dom so this test fails
   const hiddenButton = ftpo.find('button').at(0);
-  hiddenButton.getDOMNode().dispatchEvent(new Event('focusin'));
+  ftpo
+    .find('.dqpl-offscreen')
+    .getDOMNode()
+    .dispatchEvent(new Event('focusin', { target: hiddenButton.getDOMNode() }));
   ftpo.update();
   expect(
     ftpo

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   "dependencies": {
     "classnames": "^2.2.6",
     "focus-trap-react": "^3.0.5",
+    "focusable": "^2.3.0",
     "keyname": "^0.1.0",
     "prop-types": "^15.6.0",
     "rc-tooltip": "^3.7.2",

--- a/src/components/FirstTimePointOut/index.js
+++ b/src/components/FirstTimePointOut/index.js
@@ -46,7 +46,7 @@ export default class FirstTimePointOut extends Component {
   }
 
   getFocusableElements(root) {
-    return Array.from(root.querySelectorAll(focusable));
+    return Array.from(root.querySelectorAll(`${focusable}, [data-focusable]`));
   }
 
   componentDidMount() {
@@ -174,7 +174,7 @@ export default class FirstTimePointOut extends Component {
       element => element === target
     );
 
-    if (elementIndex === -1) {
+    if (elementIndex === -1 || !visibleFocusable[elementIndex]) {
       return;
     }
 
@@ -194,6 +194,10 @@ export default class FirstTimePointOut extends Component {
     const elementIndex = offscreenFocusable.findIndex(
       element => element === target
     );
+
+    if (elementIndex === -1 || !visibleFocusable[elementIndex]) {
+      return;
+    }
 
     visibleFocusable[elementIndex].classList.remove('dqpl-focus-active');
   };

--- a/src/components/FirstTimePointOut/index.js
+++ b/src/components/FirstTimePointOut/index.js
@@ -44,6 +44,30 @@ export default class FirstTimePointOut extends Component {
     this.onCloseClick = this.onCloseClick.bind(this);
   }
 
+  getFocusableElements(root) {
+    return Array.from(
+      root.querySelectorAll(
+        [
+          'a[href]',
+          'button:not([disabled])',
+          'input:not([disabled])',
+          'select:not([disabled])',
+          'textarea:not([disabled])',
+          'area[href]',
+          'iframe',
+          'object',
+          'embed',
+          '[tabindex="0"]',
+          '[contenteditable]',
+          'audio[controls]',
+          'video[controls]',
+          'summary',
+          'data-focusable'
+        ].join(', ')
+      )
+    );
+  }
+
   componentDidMount() {
     const { positionRelativeToTarget, attachOffscreenListeners } = this;
 
@@ -78,10 +102,8 @@ export default class FirstTimePointOut extends Component {
   componentWillUnmount() {
     const {
       resizeDebounce,
-      offscreenButtonRef,
+      offscreenRef,
       offscreenContentRef,
-      handleOffscreenButtonFocusIn,
-      handleOffscreenButtonFocusOut,
       handleOffscreenContentFocusIn,
       handleOffscreenContentFocusOut
     } = this;
@@ -90,15 +112,9 @@ export default class FirstTimePointOut extends Component {
       window.removeEventListener('resize', resizeDebounce);
     }
 
-    if (offscreenButtonRef) {
-      offscreenButtonRef.removeEventListener(
-        'focusin',
-        handleOffscreenButtonFocusIn
-      );
-      offscreenButtonRef.removeEventListener(
-        'focusout',
-        handleOffscreenButtonFocusOut
-      );
+    if (offscreenRef) {
+      this.offscreenRef.removeEventListener('focusin', this.handleFocusIn);
+      this.offscreenRef.removeEventListener('focusout', this.handleFocusOut);
     }
 
     if (offscreenContentRef) {
@@ -113,70 +129,92 @@ export default class FirstTimePointOut extends Component {
     }
   }
 
-  handleOffscreenButtonFocusIn = () => {
-    this.setState({ offscreenButtonFocus: true });
-  };
-
-  handleOffscreenButtonFocusOut = () => {
-    this.setState({ offscreenButtonFocus: false });
-  };
-
-  handleOffscreenContentFocusIn = () => {
-    this.setState({ offscreenContentFocus: true });
-  };
-
-  handleOffscreenContentFocusOut = () => {
-    this.setState({ offscreenContentFocus: false });
-  };
-
-  // Mirror the offscreen button focus to the visible content
+  // Mirror the offscreen focus to the visible content
   attachOffscreenListeners = () => {
-    const {
-      offscreenButtonRef,
-      offscreenContentRef,
-      handleOffscreenButtonFocusIn,
-      handleOffscreenButtonFocusOut,
-      handleOffscreenContentFocusIn,
-      handleOffscreenContentFocusOut
-    } = this;
+    const { offscreenRef, offscreenContentRef } = this;
 
-    if (offscreenButtonRef) {
-      offscreenButtonRef.removeEventListener(
+    if (offscreenRef) {
+      this.offscreenRef.removeEventListener(
         'focusin',
-        handleOffscreenButtonFocusIn
+        this.handleOffscreenFocusIn
       );
-      offscreenButtonRef.removeEventListener(
-        'focusout',
-        handleOffscreenButtonFocusOut
-      );
-      offscreenButtonRef.addEventListener(
+      this.offscreenRef.addEventListener(
         'focusin',
-        handleOffscreenButtonFocusIn
+        this.handleOffscreenFocusIn
       );
-      offscreenButtonRef.addEventListener(
+      this.offscreenRef.removeEventListener(
         'focusout',
-        handleOffscreenButtonFocusOut
+        this.handleOffscreenFocusOut
+      );
+      this.offscreenRef.addEventListener(
+        'focusout',
+        this.handleOffscreenFocusOut
       );
     }
 
+    // Manually handle offscreen content since it has a -1 tab index
     if (offscreenContentRef) {
-      offscreenContentRef.removeEventListener(
+      this.offscreenContentRef.removeEventListener(
         'focusin',
-        handleOffscreenContentFocusIn
+        this.handleOffscreenContentFocusIn
       );
-      offscreenContentRef.removeEventListener(
-        'focusout',
-        handleOffscreenContentFocusOut
-      );
-      offscreenContentRef.addEventListener(
+      this.offscreenContentRef.addEventListener(
         'focusin',
-        handleOffscreenContentFocusIn
+        this.handleOffscreenContentFocusIn
       );
-      offscreenContentRef.addEventListener(
+      this.offscreenContentRef.removeEventListener(
         'focusout',
-        handleOffscreenContentFocusOut
+        this.handleOffscreenContentFocusOut
+      );
+      this.offscreenContentRef.addEventListener(
+        'focusout',
+        this.handleOffscreenContentFocusOut
       );
     }
+  };
+
+  handleOffscreenContentFocusIn = ({ target }) => {
+    if (target === this.offscreenContentRef) {
+      this.setState({ offscreenContentFocus: true });
+    }
+  };
+
+  handleOffscreenContentFocusOut = ({ target }) => {
+    if (target === this.offscreenContentRef) {
+      this.setState({ offscreenContentFocus: false });
+    }
+  };
+
+  handleOffscreenFocusIn = ({ target }) => {
+    const { offscreenRef, visibleRef, getFocusableElements } = this;
+    const offscreenFocusable = getFocusableElements(offscreenRef);
+    const visibleFocusable = getFocusableElements(visibleRef);
+    const elementIndex = offscreenFocusable.findIndex(
+      element => element === target
+    );
+
+    if (elementIndex === -1) {
+      return;
+    }
+
+    // Tag focusable elements
+    for (var element of visibleFocusable) {
+      element.setAttribute('data-focusable', 'true');
+      element.setAttribute('tabindex', '-1');
+    }
+
+    visibleFocusable[elementIndex].classList.add('dqpl-focus-active');
+  };
+
+  handleOffscreenFocusOut = ({ target }) => {
+    const { offscreenRef, visibleRef, getFocusableElements } = this;
+    const offscreenFocusable = getFocusableElements(offscreenRef);
+    const visibleFocusable = getFocusableElements(visibleRef);
+    const elementIndex = offscreenFocusable.findIndex(
+      element => element === target
+    );
+
+    visibleFocusable[elementIndex].classList.remove('dqpl-focus-active');
   };
 
   positionRelativeToTarget = () => {
@@ -244,13 +282,7 @@ export default class FirstTimePointOut extends Component {
   }
 
   render() {
-    const {
-      show,
-      style,
-      offscreenButtonFocus,
-      offscreenContentFocus,
-      headingId
-    } = this.state;
+    const { show, style, offscreenContentFocus, headingId } = this.state;
     const {
       heading,
       ftpRef,
@@ -278,6 +310,7 @@ export default class FirstTimePointOut extends Component {
         role={target ? null : 'region'}
         aria-labelledby={heading ? headingId : null}
         aria-hidden={!!target}
+        ref={el => (this.visibleRef = el)}
       >
         {noArrow ? null : (
           <div
@@ -291,9 +324,7 @@ export default class FirstTimePointOut extends Component {
         )}
         <div className="dqpl-box">
           <button
-            className={classNames('dqpl-ftpo-dismiss fa fa-close', {
-              'dqpl-focus-active': offscreenButtonFocus
-            })}
+            className="dqpl-ftpo-dismiss fa fa-close"
             type="button"
             aria-label={dismissText}
             onClick={this.onCloseClick}
@@ -323,10 +354,10 @@ export default class FirstTimePointOut extends Component {
             className="dqpl-offscreen"
             role="region"
             aria-labelledby={heading ? headingId : null}
+            ref={el => (this.offscreenRef = el)}
           >
             <button
               type="button"
-              ref={el => (this.offscreenButtonRef = el)}
               aria-label={dismissText}
               onClick={this.onCloseClick}
             />

--- a/src/components/FirstTimePointOut/index.js
+++ b/src/components/FirstTimePointOut/index.js
@@ -2,6 +2,7 @@ import React, { Component } from 'react';
 import { createPortal } from 'react-dom';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
+import focusable from 'focusable';
 import rndid from '../../utils/rndid';
 import removeIds from '../../utils/remove-ids';
 
@@ -45,27 +46,7 @@ export default class FirstTimePointOut extends Component {
   }
 
   getFocusableElements(root) {
-    return Array.from(
-      root.querySelectorAll(
-        [
-          'a[href]',
-          'button:not([disabled])',
-          'input:not([disabled])',
-          'select:not([disabled])',
-          'textarea:not([disabled])',
-          'area[href]',
-          'iframe',
-          'object',
-          'embed',
-          '[tabindex="0"]',
-          '[contenteditable]',
-          'audio[controls]',
-          'video[controls]',
-          'summary',
-          'data-focusable'
-        ].join(', ')
-      )
-    );
+    return Array.from(root.querySelectorAll(focusable));
   }
 
   componentDidMount() {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4395,8 +4395,8 @@ focus-trap@^2.0.1:
 
 focusable@^2.3.0:
   version "2.3.0"
-  resolved "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/focusable/-/focusable-2.3.0.tgz#f9eef68dc6d6015e5526f1aa19e59f48b3ae2892"
-  integrity sha1-+e72jcbWAV5VJvGqGeWfSLOuKJI=
+  resolved "https://registry.yarnpkg.com/focusable/-/focusable-2.3.0.tgz#f9eef68dc6d6015e5526f1aa19e59f48b3ae2892"
+  integrity sha512-e63a4CAb5yLbn4Scn0wG9F+rEq4ZcbggRc9pD3hufAWf8y8dpZImdIES8YNUufRpKB+p0JS+BRd8RBU+sLAeIw==
 
 follow-redirects@^1.0.0:
   version "1.7.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4393,6 +4393,11 @@ focus-trap@^2.0.1:
   dependencies:
     tabbable "^1.0.3"
 
+focusable@^2.3.0:
+  version "2.3.0"
+  resolved "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/focusable/-/focusable-2.3.0.tgz#f9eef68dc6d6015e5526f1aa19e59f48b3ae2892"
+  integrity sha1-+e72jcbWAV5VJvGqGeWfSLOuKJI=
+
 follow-redirects@^1.0.0:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.7.0.tgz#489ebc198dc0e7f64167bd23b03c4c19b5784c76"


### PR DESCRIPTION
Dynamically set focus on focusable elements for FTPOs. This addresses an accessibility issue when using a target FTPO where inner content focusable elements did not properly receive focus and appeared to be out of focus order.

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**
- [x] Follows the commit message policy, appropriate for next version
- [x] Tested for accessibility
- [x] Code is reviewed for security
