### PR TITLE
fix: allow `word-break` inside tooltip content

### DIFF
--- a/src/components/Tooltip/index.css
+++ b/src/components/Tooltip/index.css
@@ -13,6 +13,7 @@
   background: #f2f2f2;
   padding: 8px;
   z-index: 9;
+  word-break: break-all;
 }
 
 .dqpl-rc-tooltip .rc-tooltip-arrow {


### PR DESCRIPTION
Small CSS fix to allow `word-break` in tooltip content. (Ran into it today, so thought a fix was essential).

![image](https://user-images.githubusercontent.com/20978252/66761349-bc6b4900-ee9b-11e9-9732-0d13dfcc6e65.png)


## Closes Issue:
- https://github.com/dequelabs/cauldron-react/issues/216

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**
- [x] Follows the commit message policy, appropriate for next version
- [x] Tested for accessibility
- [x] Code is reviewed for security
