### PR TITLE
chore(Toast): use the documentation <Demo /> component

### DIFF
--- a/__tests__/demo/Demo/index.js
+++ b/__tests__/demo/Demo/index.js
@@ -55,3 +55,18 @@ test('renders the propDocs table', () => {
     Object.keys(defaultProps.propDocs).length
   );
 });
+
+test('handles state.renderAfter', () => {
+  const props = {
+    ...defaultProps,
+    states: [
+      {
+        children: 'hi',
+        foo: true,
+        renderAfter: <button id="bar" />
+      }
+    ]
+  };
+  const demo = mount(<Demo {...props} />);
+  expect(demo.find('.foo').getDOMNode().nextElementSibling.id).toBe('bar');
+});

--- a/demo/Demo/index.js
+++ b/demo/Demo/index.js
@@ -4,6 +4,11 @@ import jsxStringify from 'react-element-to-jsx-string';
 import Highlight from '../Highlight';
 import './index.css';
 
+const stringifyConfig = {
+  showDefaultProps: false,
+  showFunctions: true
+};
+
 class Demo extends Component {
   static propTypes = {
     propDocs: PropTypes.object.isRequired,
@@ -19,17 +24,39 @@ class Demo extends Component {
     return (
       <div className="Demo">
         <h1>{displayName}</h1>
-        <div className="Demo-states">
-          <h2>Examples</h2>
-          {/* setting children to null in the key to avoid stringify choking on potential jsx children */}
-          {states.map(state => (
-            <div key={JSON.stringify({ ...state, children: null })}>
-              <Component {...state} />
-              <Highlight>{this.renderState(state)}</Highlight>
-            </div>
-          ))}
-          {children}
-        </div>
+        {states.length ? (
+          <div className="Demo-states">
+            <h2>Examples</h2>
+            {/* setting children to null in the key to avoid stringify choking on potential jsx children */}
+            {states.map(state => {
+              const { renderAfter, ...thinState } = state;
+              const componentMarkup = this.renderState(thinState);
+              const afterMarkup =
+                renderAfter && jsxStringify(renderAfter, stringifyConfig);
+
+              return (
+                <div
+                  key={JSON.stringify({
+                    ...thinState,
+                    children:
+                      typeof state.children === 'string' ? state.children : null
+                  })}
+                >
+                  <Component {...thinState} />
+                  {renderAfter}
+                  <Highlight>
+                    {`${componentMarkup}${
+                      afterMarkup ? `\n${afterMarkup}` : ''
+                    }`}
+                  </Highlight>
+                </div>
+              );
+            })}
+            {children}
+          </div>
+        ) : (
+          children
+        )}
         <div className="Demo-props">
           <h2>Props</h2>
           <table>
@@ -76,9 +103,7 @@ class Demo extends Component {
     }
 
     const Tag = displayName;
-    return jsxStringify(<Tag {...state} />, {
-      showDefaultProps: false
-    });
+    return jsxStringify(<Tag {...state} />, stringifyConfig);
   };
 }
 

--- a/demo/patterns/components/Toast/index.js
+++ b/demo/patterns/components/Toast/index.js
@@ -1,106 +1,128 @@
 import React, { Component } from 'react';
-import Highlight from 'demo/Highlight';
 import { Button, Toast, Link } from 'src/';
+import DemoComponent from 'demo/Demo';
+import { children } from 'demo/props';
 
 export default class Demo extends Component {
-  constructor() {
-    super();
+  state = {
+    type: null
+  };
 
-    this.state = {};
-    this.onToastDismiss = this.onToastDismiss.bind(this);
+  onTriggerClick(type) {
+    this.setState({ type });
   }
 
-  onTriggerClick(nextType) {
-    this.setState({ type: null, nextType });
-  }
+  onToastDismiss = dismissed => {
+    const { type } = this.state;
 
-  onToastDismiss() {
-    const { type, nextType } = this.state;
-    const trigger = this[type];
+    if (dismissed !== type) {
+      return;
+    }
 
-    // return focus back to the dismissed toast's trigger
-    if (trigger) {
+    this.setState({ type: null }, () => {
+      const trigger = this[type];
+
+      if (!trigger) {
+        return;
+      }
+
+      // return focus back to the dismissed toast's trigger
       trigger.focus();
-    }
-
-    this.setState({ type: nextType ? nextType : null, nextType: null });
-  }
-
-  componentDidUpdate(prevProps, prevState) {
-    const { nextType } = this.state;
-    if (nextType && nextType !== prevState.nextType) {
-      this.setState({ type: nextType });
-    }
-  }
+    });
+  };
 
   render() {
     const { type } = this.state;
 
     return (
-      <div>
-        <Toast
-          type={'confirmation'}
-          onDismiss={this.onToastDismiss}
-          show={type === 'confirmation'}
-        >
-          {'Everything is good!'}
-        </Toast>
-        <Toast
-          type={'caution'}
-          onDismiss={this.onToastDismiss}
-          show={type === 'caution'}
-        >
-          {'Your software is out of date, please update it.'}
-        </Toast>
+      <DemoComponent
+        component={Toast}
+        states={[
+          {
+            type: 'confirmation',
+            children: 'Your toast is ready!',
+            show: type === 'confirmation',
+            autoHide: 5000,
+            onDismiss: () => this.onToastDismiss('confirmation'),
+            renderAfter: (
+              <Button
+                onClick={() => this.onTriggerClick('confirmation')}
+                buttonRef={el => (this.confirmation = el)}
+              >
+                Confirmation
+              </Button>
+            )
+          },
+          {
+            type: 'caution',
+            children: 'The toast is getting toasty...',
+            onDismiss: () => this.onToastDismiss('caution'),
+            show: type === 'caution',
+            renderAfter: (
+              <Button
+                variant="secondary"
+                onClick={() => this.onTriggerClick('caution')}
+                buttonRef={el => (this.caution = el)}
+              >
+                Caution
+              </Button>
+            )
+          },
+          {
+            type: 'action-needed',
+            children:
+              'You burnt the toast! Check yourself before you wreck yourself...',
+            show: false,
+            renderAfter: (
+              <Button
+                variant="error"
+                onClick={() => this.onTriggerClick('action-needed')}
+                buttonRef={el => (this['action-needed'] = el)}
+              >
+                Action Needed
+              </Button>
+            )
+          }
+        ]}
+        propDocs={{
+          children,
+          show: {
+            type: 'boolean',
+            description: 'whether or not to show the toast'
+          },
+          type: {
+            type: 'string',
+            required: true,
+            description: '"confirmation", "caution", or "action-needed"'
+          },
+          onDismiss: {
+            type: 'function',
+            description: 'function to be executed when toast is dismissed'
+          },
+          autoHide: {
+            type: 'number',
+            description:
+              'optional timeout (ms) before automatically hiding the toast'
+          },
+          dismissText: {
+            type: 'string',
+            description:
+              'text to be added as the aria-label of the "x" dismiss button (default: "Dismiss")'
+          },
+          toastRef: {
+            type: 'function',
+            description:
+              'optional ref function to get a handle on the toast element'
+          }
+        }}
+      >
         <Toast type={'action-needed'} show={type === 'action-needed'}>
           <span>{'You have entered an alternate universe.'}</span>
-          <Link href="#" onClick={this.onToastDismiss}>
-            {'Go back to non-alternate universe!'}
+          <Link href="#" onClick={() => this.onToastDismiss('action-needed')}>
+            Go back to non-alternate universe!
           </Link>
         </Toast>
-        <h1>Toasts</h1>
-        <h2>Demo</h2>
-        <Button
-          secondary={true}
-          onClick={() => this.onTriggerClick('confirmation')}
-          buttonRef={el => (this.confirmation = el)}
-        >
-          {'Confirmation'}
-        </Button>
-        <Button
-          secondary={true}
-          onClick={() => this.onTriggerClick('caution')}
-          buttonRef={el => (this.caution = el)}
-        >
-          {'Caution'}
-        </Button>
-        <Button
-          secondary={true}
-          onClick={() => this.onTriggerClick('action-needed')}
-          buttonRef={el => (this['action-needed'] = el)}
-        >
-          {'Action Needed'}
-        </Button>
-        <h2>Code Sample</h2>
-        <Highlight language="javascript">
-          {`
-    import React from 'react';
-    import { Toast } from 'cauldron-react';
-
-    // a toast that hides itself after 7 seconds...
-    const Demo = () => (
-      <Toast
-        type={'confirmation'}
-        autoHide={7000}
-        dismissText={'Close'}
-        onClose={() => console.log('toast dismissed!')}
-      >
-        {'Everything is good!'}
-      </Toast>
-    );
-          `}
-        </Highlight>
-      </div>
+      </DemoComponent>
     );
   }
 }

--- a/src/components/Toast/index.js
+++ b/src/components/Toast/index.js
@@ -161,3 +161,5 @@ export default class Toast extends Component {
     );
   }
 }
+
+Toast.displayName = 'Toast';


### PR DESCRIPTION
To get all things Toast documented, I had to make a couple enhancements to the demo component:
- renders string children in code examples
- supports a `renderAfter` state property to allow additional nodes to be rendered for each state

check out the [toast demo (deploy preview)](https://5e09b0cfad06f40007c46b6d--cauldron-react.netlify.com/components/toast)

![](https://user-images.githubusercontent.com/3180185/71573468-e4c91380-2a98-11ea-8946-cf564ea71561.gif)


Closes #166 

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**
- [x] Follows the commit message policy, appropriate for next version
- [x] Tested for accessibility
- [x] Code is reviewed for security
