### PR TITLE
feat(Demo): support rendering additional UI before/after component demo

### DIFF
--- a/__tests__/demo/Demo/index.js
+++ b/__tests__/demo/Demo/index.js
@@ -56,17 +56,19 @@ test('renders the propDocs table', () => {
   );
 });
 
-test('handles state.renderAfter', () => {
+test('handles state.DEMO_renderAfter/DEMO_renderBefore', () => {
   const props = {
     ...defaultProps,
     states: [
       {
         children: 'hi',
         foo: true,
-        renderAfter: <button id="bar" />
+        DEMO_renderBefore: <button id="baz" />,
+        DEMO_renderAfter: <button id="bar" />
       }
     ]
   };
   const demo = mount(<Demo {...props} />);
+  expect(demo.find('.foo').getDOMNode().previousElementSibling.id).toBe('baz');
   expect(demo.find('.foo').getDOMNode().nextElementSibling.id).toBe('bar');
 });

--- a/demo/Demo/index.js
+++ b/demo/Demo/index.js
@@ -29,10 +29,15 @@ class Demo extends Component {
             <h2>Examples</h2>
             {/* setting children to null in the key to avoid stringify choking on potential jsx children */}
             {states.map(state => {
-              const { renderAfter, ...thinState } = state;
+              const {
+                DEMO_renderAfter,
+                DEMO_renderBefore,
+                ...thinState
+              } = state;
               const componentMarkup = this.renderState(thinState);
               const afterMarkup =
-                renderAfter && jsxStringify(renderAfter, stringifyConfig);
+                DEMO_renderAfter &&
+                jsxStringify(DEMO_renderAfter, stringifyConfig);
 
               return (
                 <div
@@ -42,8 +47,9 @@ class Demo extends Component {
                       typeof state.children === 'string' ? state.children : null
                   })}
                 >
+                  {DEMO_renderBefore}
                   <Component {...thinState} />
-                  {renderAfter}
+                  {DEMO_renderAfter}
                   <Highlight>
                     {`${componentMarkup}${
                       afterMarkup ? `\n${afterMarkup}` : ''

--- a/demo/patterns/components/Toast/index.js
+++ b/demo/patterns/components/Toast/index.js
@@ -44,7 +44,7 @@ export default class Demo extends Component {
             show: type === 'confirmation',
             autoHide: 5000,
             onDismiss: () => this.onToastDismiss('confirmation'),
-            renderAfter: (
+            DEMO_renderAfter: (
               <Button
                 onClick={() => this.onTriggerClick('confirmation')}
                 buttonRef={el => (this.confirmation = el)}
@@ -58,7 +58,7 @@ export default class Demo extends Component {
             children: 'The toast is getting toasty...',
             onDismiss: () => this.onToastDismiss('caution'),
             show: type === 'caution',
-            renderAfter: (
+            DEMO_renderAfter: (
               <Button
                 variant="secondary"
                 onClick={() => this.onTriggerClick('caution')}
@@ -73,7 +73,7 @@ export default class Demo extends Component {
             children:
               'You burnt the toast! Check yourself before you wreck yourself...',
             show: false,
-            renderAfter: (
+            DEMO_renderAfter: (
               <Button
                 variant="error"
                 onClick={() => this.onTriggerClick('action-needed')}


### PR DESCRIPTION
given that in the future our components _could_ use a prop named `renderAfter`, I decided it'd be best to avoid namespace collisions. This patch renames the `states` property `renderAfter` to `DEMO_renderAfter` and adds a new `DEMO_renderBefore` hook to support rendering additional UI _before_ the demo generated component (this is handy if you want add a nice descriptive heading to each state demo to give the page some nice structure 😎 )

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**
- [x] Follows the commit message policy, appropriate for next version
- [x] Tested for accessibility
- [x] Code is reviewed for security
