### PR TITLE
fix(Demo): prevent error given a react node state prop

### DIFF
--- a/demo/Demo/index.js
+++ b/demo/Demo/index.js
@@ -35,13 +35,7 @@ class Demo extends Component {
                 renderAfter && jsxStringify(renderAfter, stringifyConfig);
 
               return (
-                <div
-                  key={JSON.stringify({
-                    ...thinState,
-                    children:
-                      typeof state.children === 'string' ? state.children : null
-                  })}
-                >
+                <div key={componentMarkup}>
                   <Component {...thinState} />
                   {renderAfter}
                   <Highlight>


### PR DESCRIPTION
`JSON.stringify` would choke here if any prop of type `PropTypes.node` were passed in as `states` to the `<Demo />` component.

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**
- [x] Follows the commit message policy, appropriate for next version
- [x] Tested for accessibility
- [x] Code is reviewed for security
