### PR TITLE
feat(Checkbox): support offscreen label

### DIFF
--- a/src/components/Checkbox/index.js
+++ b/src/components/Checkbox/index.js
@@ -6,7 +6,7 @@ export default class Checkbox extends Component {
   static propTypes = {
     id: PropTypes.string.isRequired,
     name: PropTypes.string.isRequired,
-    label: PropTypes.string.isRequired,
+    label: PropTypes.node.isRequired,
     value: PropTypes.string.isRequired,
     checked: PropTypes.bool,
     disabled: PropTypes.bool,

--- a/types.d.ts
+++ b/types.d.ts
@@ -294,7 +294,7 @@ interface CheckboxProps
   extends Omit<React.InputHTMLAttributes<HTMLInputElement>, 'onChange'> {
   id: string;
   name: string;
-  label: string;
+  label: React.ReactNode;
   value: string;
   checked?: boolean;
   className?: string;


### PR DESCRIPTION
I changed the label PropType, so it can accept something like `<Offscreen>label my checkbox</Offscreen>`.

- ## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**
- [x] Follows the commit message policy, appropriate for next version
- [x] Tested for accessibility
- [x] Code is reviewed for security
