### PR TITLE
fix(Select): Remove unused required props

### DIFF
--- a/__tests__/typechecks.tsx
+++ b/__tests__/typechecks.tsx
@@ -181,12 +181,10 @@ const select = () => (
   <Select
     className="hi"
     label="7"
-    listId="sdfsdf"
     onKeyDown={noopEventHandler}
     onSelect={noopEventHandler}
     required
     value="6"
-    selectedId="7"
     options={[
       { value: 'Monday' },
       { value: 'Tuesday' },

--- a/src/components/Select/index.tsx
+++ b/src/components/Select/index.tsx
@@ -18,8 +18,6 @@ export interface SelectProps
   > {
   options: SelectOption[];
   label: string;
-  listId: string;
-  selectedId: string;
   className?: string;
   onKeyDown: (e: React.KeyboardEvent<HTMLElement>) => void;
   onSelect: (option: SelectOption) => void;


### PR DESCRIPTION
The `listId` and `selectedId` are marked as required props by the TypeScript definition, but are never used by the `<Select/>` component. This patch removes the props from the definition.

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**
- [ ] Follows the commit message policy, appropriate for next version
- [ ] Tested for accessibility
- [ ] Code is reviewed for security
